### PR TITLE
removing /en/ from all the links

### DIFF
--- a/docs/faq/faq-general.md
+++ b/docs/faq/faq-general.md
@@ -59,7 +59,7 @@ Not every block is implemented the same, so the only way to figure out is by tri
 - If it's a deep packet inspection (DPI) block, you may have some success with DPI circumvention tools such as [GoodbyeDPI](https://github.com/ValdikSS/GoodbyeDPI) or [PowerTunnel](https://github.com/krlvm/PowerTunnel-Android).
 
 
-- Otherwise, a VPN with servers in a country without censorship blocks will usually work. [Refer to our VPN FAQ section for more information](/en/faq/vpn).
+- Otherwise, a VPN with servers in a country without censorship blocks will usually work. [Refer to our VPN FAQ section for more information](/faq/vpn).
 
 
 

--- a/docs/faq/faq-streaming.md
+++ b/docs/faq/faq-streaming.md
@@ -49,7 +49,7 @@ Same process applies, go to the `#index` channel in our [Discord](https://discor
 
 ## Why is there no OP/ED playing for a particular anime on a streaming site?
 
-Streaming sites use torrent releases as a source. Sometimes they get a release with ordered chapters/linked mkvs. Since these are meant to be downloaded, the op/ed come as a separate file and automatically play inside each episode at the correct time. This can be fixed by combining them back into a single file, but streaming sites will rarely make the effort. If you want the complete experience with OP/EDs, check out the [ordered chapters section here](/en/guides/sourcing) for more information about them and ways to fix it
+Streaming sites use torrent releases as a source. Sometimes they get a release with ordered chapters/linked mkvs. Since these are meant to be downloaded, the op/ed come as a separate file and automatically play inside each episode at the correct time. This can be fixed by combining them back into a single file, but streaming sites will rarely make the effort. If you want the complete experience with OP/EDs, check out the [ordered chapters section here](/guides/sourcing) for more information about them and ways to fix it
 
 ## Where do unofficial streaming sites get their streams from?
 
@@ -59,4 +59,4 @@ Note that these "rips" are not screen captures, they're unaltered WEB-DLs. You c
 
 ## Why are the subtitles for this anime on streaming site X different from site Y or torrent Z?
 
-It depends on which source is used by different streaming sites. The most common one is subtitles from the official stream. Fansubbers often take this as a base and improve upon it by adding effects, translating signs and making edits. Some sites may be using these fansubs as a source. For more information -  [Sourcing - Fansubs.](/en/guides/sourcing#fansubs)
+It depends on which source is used by different streaming sites. The most common one is subtitles from the official stream. Fansubbers often take this as a base and improve upon it by adding effects, translating signs and making edits. Some sites may be using these fansubs as a source. For more information -  [Sourcing - Fansubs.](/guides/sourcing#fansubs)

--- a/docs/faq/faq-torrent.md
+++ b/docs/faq/faq-torrent.md
@@ -68,7 +68,7 @@ Check out the [sourcing guide](/guides/sourcing) for more detailed information o
 
 For airing anime ripped from official streams, the size is always 1.3-1.4 GB. Mini encodes or the versions on streaming sites are encoded from this and are in the range of 200-400 MB. None of those can be called "high quality". A good encode using the blu-ray as a source is usually between 1 and 2 GB, and as high as 4-5 GB where it's needed. 
 
-Size can be used to judge web sources, but it's not the best measure of quality for BDRips. Even though the raw BDMV is larger, a good encode will give you the better experience. Check out [Sourcing - Quality](/en/guides/sourcing#quality) for more.
+Size can be used to judge web sources, but it's not the best measure of quality for BDRips. Even though the raw BDMV is larger, a good encode will give you the better experience. Check out [Sourcing - Quality](/guides/sourcing#quality) for more.
 
 ## What does it mean for a torrent to be "stalled"?
 
@@ -119,4 +119,4 @@ Anime.Name.S01E01.1080p.BluRay.Opus2.0.x264-Hi10p-Group.mkv
 | Dual Audio      | Has two audio tracks. Typically English and Japanese              |
 | [F0EAA72E]      | Random string at the end of the filename is typically CRC32.      |
 
-For more details, check out the sourcing guide - [basics](/en/guides/sourcing#basics) and [CRC32.](/en/guides/sourcing#crc32)
+For more details, check out the sourcing guide - [basics](/guides/sourcing#basics) and [CRC32.](/guides/sourcing#crc32)

--- a/docs/getting-started/anime.md
+++ b/docs/getting-started/anime.md
@@ -23,11 +23,11 @@ Torrent files can be found and downloaded from trackers like [nyaa.si](https://n
 
 The downloaded .torrent file or the magnet link has to be opened in your torrent client - [qBittorrent](https://www.qbittorrent.org/download.php) for PC and [LibreTorrent](https://play.google.com/store/apps/details?id=org.proninyaroslav.libretorrent)/[Flud](https://play.google.com/store/apps/details?id=com.delphicoder.flud) for Android. After the download is complete, the torrents do not need to be removed from the client.
 
-The speed is dependent on the number of seeds and their connection quality. You can connect to more seeds and improve speeds with [port forwarding](/en/guides/torrenting#how-to-port-forward). You may want to use a [VPN](/en/faq/vpn) or a [seedbox](/en/guides/torrenting#what-is-a-seedbox) for downloading torrents to avoid receiving a copyright infringement notice from your ISP.
+The speed is dependent on the number of seeds and their connection quality. You can connect to more seeds and improve speeds with [port forwarding](/guides/torrenting#how-to-port-forward). You may want to use a [VPN](/faq/vpn) or a [seedbox](/guides/torrenting#what-is-a-seedbox) for downloading torrents to avoid receiving a copyright infringement notice from your ISP.
 
 Advantages of torrents include access to more options with better quality/size ratios, and automation through RSS or Sonarr.
 
-Read more: [Torrenting Guide](/en/guides/torrenting), [RSS Tutorial](/tutorials/rss)
+Read more: [Torrenting Guide](/guides/torrenting), [RSS Tutorial](/tutorials/rss)
 
 ## Playback
 
@@ -43,4 +43,4 @@ VLC is not recommended because it displays wrong colours, introduces visual arti
 
 **TV/Media Servers:** [Kodi](https://kodi.tv), [Plex](https://www.plex.tv/), [Jellyfin](https://jellyfin.org/)
 
-Read more: [Playback Guide](/en/guides/playback)
+Read more: [Playback Guide](/guides/playback)

--- a/docs/guides/torrenting.md
+++ b/docs/guides/torrenting.md
@@ -10,7 +10,7 @@ order: -3
 The process of sharing files through torrents is completely legal. Transferring copyright infringing files may be illegal depending on your local laws. Copyright organizations may scrape lists of peers, and send takedown notices to the internet service provider of users participating in the swarms of files that are under copyright. In some jurisdictions, copyright holders may start lawsuits against uploaders or downloaders for infringement. However, they are less common for anime compared to Movies/TV shows.
 
 !!!info
-You may want to use a [VPN](/en/faq/vpn) or a [seedbox](/en/guides/torrenting#what-is-a-seedbox) for downloading torrents to avoid receiving a copyright infringement notice from your ISP or a copyright body, and having your internet limited or revoked.
+You may want to use a [VPN](/faq/vpn) or a [seedbox](/guides/torrenting#what-is-a-seedbox) for downloading torrents to avoid receiving a copyright infringement notice from your ISP or a copyright body, and having your internet limited or revoked.
 !!!
 
 ## Basics
@@ -64,7 +64,7 @@ Keep in mind that some clients (such as newer versions of uTorrent and BitTorren
 
 ### How do I torrent?
 
-- First, find a torrent file or magnet link for the content you want to download. Such files can be found on websites (called [trackers](/en/guides/torrenting#trackers)) like nyaa.si.
+- First, find a torrent file or magnet link for the content you want to download. Such files can be found on websites (called [trackers](/guides/torrenting#trackers)) like nyaa.si.
 
 - A `.torrent` file can be added to the client by double clicking it or use the client and browse to the location of the file manually.
 

--- a/docs/hidden/faq-general.md
+++ b/docs/hidden/faq-general.md
@@ -26,7 +26,7 @@ This also applies to feature suggestion posts for apps and services.
 
 For airing anime ripped from official streams, the size is always 1.3-1.4 GB. Mini encodes or the versions on streaming sites are encoded from this and are in the range of 200-400 MB. None of those can be called "high quality". A good encode using the blu-ray as a source is usually between 1 and 2 GB, and as high as 4-5 GB where it's needed. 
 
-Size can be used to judge web sources, but it's not the best measure of quality for BDRips. Even though the raw BDMV is larger, a good encode will give you the better experience. Check out [Sourcing - Quality](/en/guides/sourcing#quality) for more.
+Size can be used to judge web sources, but it's not the best measure of quality for BDRips. Even though the raw BDMV is larger, a good encode will give you the better experience. Check out [Sourcing - Quality](/guides/sourcing#quality) for more.
 
 ## Where can I download smaller sized episodes?
 
@@ -44,7 +44,7 @@ Nyaa and torrents have something called dual audio where the mkv files include b
 
 ## How can I add/remove subtitles or audio?
 
-[Mkvtoolnix](https://mkvtoolnix.download/) is the tool for all kinds of muxing, simply drag and drop the files and you'll be able to select the streams to keep in the final output. This is a lossless process different from encoding and takes only a few seconds. Batch muxing and more - [Guides - Muxing.](/en/guides/sourcing#muxing)
+[Mkvtoolnix](https://mkvtoolnix.download/) is the tool for all kinds of muxing, simply drag and drop the files and you'll be able to select the streams to keep in the final output. This is a lossless process different from encoding and takes only a few seconds. Batch muxing and more - [Guides - Muxing.](/guides/sourcing#muxing)
 
 ## Where do unofficial streaming sites get their streams from?
 
@@ -54,7 +54,7 @@ Note that these "rips" are not screen captures, they're unaltered WEB-DLs. You c
 
 ## Why are the subtitles for this anime on streaming site X different from site Y or torrent Z?
 
-It depends on which source is used by different streaming sites. The most common one is subtitles from the official stream. Fansubbers often take this as a base and improve upon it by adding effects, translating signs and making edits. Some sites may be using these fansubs as a source. For more information -  [Sourcing - Fansubs.](/en/guides/sourcing#fansubs)
+It depends on which source is used by different streaming sites. The most common one is subtitles from the official stream. Fansubbers often take this as a base and improve upon it by adding effects, translating signs and making edits. Some sites may be using these fansubs as a source. For more information -  [Sourcing - Fansubs.](/guides/sourcing#fansubs)
 
 ## How long will I have to wait for the newest anime episode to be available on streaming sites and torrents?
 
@@ -70,11 +70,11 @@ Not every block is implemented the same, so the only way to figure out is by tri
 - If it's a deep packet inspection (DPI) block, you may have some success with DPI circumvention tools such as [GoodbyeDPI](https://github.com/ValdikSS/GoodbyeDPI) or [PowerTunnel](https://github.com/krlvm/PowerTunnel-Android).
 
 
-- Otherwise, a VPN with servers in a country without censorship blocks will usually work. [Refer to our VPN FAQ section for more information](/en/faq/vpn).
+- Otherwise, a VPN with servers in a country without censorship blocks will usually work. [Refer to our VPN FAQ section for more information](/faq/vpn).
 
 ## Why is there no OP/ED playing for a particular anime on a streaming site?
 
-Streaming sites use torrent releases as a source. Sometimes they get a release with ordered chapters/linked mkvs. Since these are meant to be downloaded, the op/ed come as a separate file and automatically play inside each episode at the correct time. This can be fixed by combining them back into a single file, but streaming sites will rarely make the effort. If you want the complete experience with OP/EDs, check out the [ordered chapters section here](/en/guides/sourcing) for more information about them and ways to fix it
+Streaming sites use torrent releases as a source. Sometimes they get a release with ordered chapters/linked mkvs. Since these are meant to be downloaded, the op/ed come as a separate file and automatically play inside each episode at the correct time. This can be fixed by combining them back into a single file, but streaming sites will rarely make the effort. If you want the complete experience with OP/EDs, check out the [ordered chapters section here](/guides/sourcing) for more information about them and ways to fix it
 
 ## Where can I download high quality anime soundtracks?
 
@@ -110,4 +110,4 @@ Streaming sites use torrent releases as a source. Sometimes they get a release w
 ( BD &emsp; &emsp;&emsp;&emsp;&emsp;&emsp; 1080p&emsp;&emsp; &emsp;HEVC x265 &emsp; 10-bit &emsp; &emsp; FLAC ) [2CE04B17]
 ( Source - Blu-ray&emsp; Resolution &emsp;&emsp;Codec &emsp; &emsp; Bit Depth &emsp;Audio)&emsp;[CRC32]
 
-For more details, check out the sourcing guide - [basics](/en/guides/sourcing#basics) and [CRC32.](/en/guides/sourcing#crc32)
+For more details, check out the sourcing guide - [basics](/guides/sourcing#basics) and [CRC32.](/guides/sourcing#crc32)

--- a/docs/hidden/faq.md
+++ b/docs/hidden/faq.md
@@ -42,7 +42,7 @@ This also applies to feature suggestion posts for apps and services.
 
 For airing anime ripped from official streams, the size is around 1.4GB. Mini encodes or the versions on streaming sites are encoded from this and are in the range of 200-400 MB. None of those can be called "high quality". A good encode using the blu-ray as a source is usually between 1 and 2 GB, and as high as 4-5 GB where it's needed. Sometimes the best release could be a remux at about ~6GB per episode.
 
-Size can be used to judge web sources, but it's not the best measure of quality for BDRips. Even though the raw BDMV is larger, a good encode will give you the better experience. Check out [Quality](/en/guides/quality) for more.
+Size can be used to judge web sources, but it's not the best measure of quality for BDRips. Even though the raw BDMV is larger, a good encode will give you the better experience. Check out [Quality](/guides/quality) for more.
 
 ## Where can I download smaller sized episodes?
 
@@ -70,7 +70,7 @@ Note that these "rips" are not screen captures, they're unaltered WEB-DLs. You c
 
 ## Why are the subtitles for this anime on streaming site X different from site Y or torrent Z?
 
-It depends on which source is used by different streaming sites. The most common one is subtitles from the official stream. Fansubbers often take this as a base and improve upon it by adding effects, translating signs and making edits. Some sites may be using these fansubs as a source. For more information -  [Sourcing - Fansubs.](/en/guides/sourcing#fansubs)
+It depends on which source is used by different streaming sites. The most common one is subtitles from the official stream. Fansubbers often take this as a base and improve upon it by adding effects, translating signs and making edits. Some sites may be using these fansubs as a source. For more information -  [Sourcing - Fansubs.](/guides/sourcing#fansubs)
 
 ## How long will I have to wait for the newest anime episode to be available on streaming sites and torrents?
 
@@ -86,11 +86,11 @@ Not every block is implemented the same, so the only way to figure out is by tri
 - If it's a deep packet inspection (DPI) block, you may have some success with DPI circumvention tools such as [GoodbyeDPI](https://github.com/ValdikSS/GoodbyeDPI) or [PowerTunnel](https://github.com/krlvm/PowerTunnel-Android).
 
 
-- Otherwise, a VPN with servers in a country without censorship blocks will usually work. [Refer to our VPN FAQ section for more information](/en/faq/vpn).
+- Otherwise, a VPN with servers in a country without censorship blocks will usually work. [Refer to our VPN FAQ section for more information](/faq/vpn).
 
 ## Why is there no OP/ED playing for a particular anime on a streaming site?
 
-Streaming sites use torrent releases as a source. Sometimes they get a release with ordered chapters/linked mkvs. Since these are meant to be downloaded, the op/ed come as a separate file and automatically play inside each episode at the correct time. This can be fixed by combining them back into a single file, but streaming sites will rarely make the effort. If you want the complete experience with OP/EDs, check out the [ordered chapters section here](/en/guides/sourcing) for more information about them and ways to fix it
+Streaming sites use torrent releases as a source. Sometimes they get a release with ordered chapters/linked mkvs. Since these are meant to be downloaded, the op/ed come as a separate file and automatically play inside each episode at the correct time. This can be fixed by combining them back into a single file, but streaming sites will rarely make the effort. If you want the complete experience with OP/EDs, check out the [ordered chapters section here](/guides/sourcing) for more information about them and ways to fix it
 
 # Music
 
@@ -217,7 +217,7 @@ However, they're not the best source for older anime or anime that has been rele
 
 - [A Certain Fansubber's Index](https://docs.google.com/spreadsheets/d/1PJYwhjzLNPXV2X1np-S4rdZE4fb7pxp-QbHY1O0jH6Q/htmlview)
 
-Check out the [sourcing guide](/en/guides/sourcing) for more detailed information on finding the best release for any particular anime.
+Check out the [sourcing guide](/guides/sourcing) for more detailed information on finding the best release for any particular anime.
 
 ## What do the things in brackets mean at the end of a torrent title?
 

--- a/docs/hidden/quick-start.md
+++ b/docs/hidden/quick-start.md
@@ -25,11 +25,11 @@ Torrent files can be found and downloaded from trackers like [Nyaa](https://nyaa
 
 The downloaded .torrent file or the magnet link has to be opened in your torrent client - [qBittorrent](https://www.qbittorrent.org/download.php) for PC and [LibreTorrent](https://play.google.com/store/apps/details?id=org.proninyaroslav.libretorrent)/[Flud](https://play.google.com/store/apps/details?id=com.delphicoder.flud) for Android. The torrents do not need to be removed from the client after the download is complete.
 
-The speed is dependent on the number of seeds and their connection quality. You can connect to more seeds and improve speeds with [port forwarding](/en/guides/torrenting#how-to-port-forward). You may want to use a [VPN](/en/faq/vpn) or a [seedbox](/en/guides/torrenting#what-is-a-seedbox) for downloading torrents to avoid receiving a copyright infringement notice from your ISP.
+The speed is dependent on the number of seeds and their connection quality. You can connect to more seeds and improve speeds with [port forwarding](/guides/torrenting#how-to-port-forward). You may want to use a [VPN](/faq/vpn) or a [seedbox](/guides/torrenting#what-is-a-seedbox) for downloading torrents to avoid receiving a copyright infringement notice from your ISP.
 
 Advantages of torrents include access to a large variety of options with better quality/size ratios and automation through RSS or Sonarr.
 
-Read more: [Sourcing Guide](/guides/sourcing), [Torrenting Guide](/en/guides/torrenting), [RSS Tutorial](/tutorials/rss)
+Read more: [Sourcing Guide](/guides/sourcing), [Torrenting Guide](/guides/torrenting), [RSS Tutorial](/tutorials/rss)
 
 ### Playback
 
@@ -45,7 +45,7 @@ Do not use VLC
 
 **TV/Media Servers:** [Kodi](https://kodi.tv), [Plex](https://www.plex.tv/), [Emby](https://emby.media/), [Jellyfin](https://jellyfin.org/)
 
-Read more: [Playback Guide](/en/guides/playback)
+Read more: [Playback Guide](/guides/playback)
 
 ## Literature
 

--- a/docs/sourcing/streaming.md
+++ b/docs/sourcing/streaming.md
@@ -18,7 +18,7 @@ While one can choose between the numerous popular sites listed both here and on 
 
 ### Scrapers vs Self-Hosted Sites
 
-A "scraper" is a site that takes content hosted on other sites, and puts it on their own. These are the streaming site equivalent to [manga aggregator sites](https://thewiki.moe/en/guides/literature#sourcing) that are mentioned in the literature page. These can lead to extensive libraries without the need for the site owners to host the content themselves, usually at the expense of video quality. By far the most commonly scraped from site is [gogoanime](https://gogoanime.lu/), so much so that most streaming sites in existence are gogoanime scrapers.
+A "scraper" is a site that takes content hosted on other sites, and puts it on their own. These are the streaming site equivalent to [manga aggregator sites](https://thewiki.moe/guides/literature#sourcing) that are mentioned in the literature page. These can lead to extensive libraries without the need for the site owners to host the content themselves, usually at the expense of video quality. By far the most commonly scraped from site is [gogoanime](https://gogoanime.lu/), so much so that most streaming sites in existence are gogoanime scrapers.
 
 **Examples of scraper sites:** [Animixplay](https://animixplay.to/), [11anime](https://11anime.fr/), [5anime](https://5anime.net/), [Genoanime](https://genoanime.com/), [Animeflix](https://animeflix.sbs/)
 


### PR DESCRIPTION
Wiki.js had `/en/` indicating the locale in the links and that carried over to retype which ended up breaking several links. For example:
```diff
-[Sourcing - Quality](/en/guides/sourcing#quality)
+[Sourcing - Quality](/guides/sourcing#quality)
```