### PR TITLE
fix: replace imgur links with github links

### DIFF
--- a/docs/advanced/muxing.md
+++ b/docs/advanced/muxing.md
@@ -239,7 +239,7 @@ for file in *.ass do; python -m subdigest -i "${file}" --selection-set "text" "\
 ## Styling
 
 - The dialogue style must be readable without being distracting.
-- Feel free to restyle bad styling. Here's a reference for some good [dialogue fonts](https://i.imgur.com/qQUFf7n.png).
+- Feel free to restyle bad styling. Here's a reference for some good [dialogue fonts](https://user-images.githubusercontent.com/78981416/233718169-0c5bf0d5-3ba4-4836-b41b-6c7c1c0d14b1.png).
 - You can also copy styling from existing groups like [GJM](https://nyaa.si/user/GoodJobMedia), [Kaleido](https://nyaa.si/user/Kaleido-subs), or [DDY](https://nyaa.si/user/DameDesuYo).
 - Try to match the styling of previous seasons of the same show to maintain consistency. Although this isn't mandatory and should be avoided if previous season releases had bad styling.
 

--- a/docs/advanced/release-standards.md
+++ b/docs/advanced/release-standards.md
@@ -221,7 +221,7 @@ for file in *.ass do; python -m subdigest -i "${file}" --selection-set "text" "\
 ### Styling
 
 - The dialogue style must be readable without being distracting.
-- Feel free to restyle bad styling. Here's a reference for some good [dialogue fonts](https://i.imgur.com/qQUFf7n.png).
+- Feel free to restyle bad styling. Here's a reference for some good [dialogue fonts](https://user-images.githubusercontent.com/78981416/233718844-5d05ae4e-228a-4bfc-b9fb-e7209b5ac037.png).
 - You can also copy styling from existing groups like [GJM](https://nyaa.si/user/GoodJobMedia), [Kaleido](https://nyaa.si/user/Kaleido-subs), or [DDY](https://nyaa.si/user/DameDesuYo).
 - Try to match the styling of previous seasons of the same show to maintain consistency. Although this isn't mandatory and should be avoided if previous season releases had bad styling.
 

--- a/docs/getting-started/literature.md
+++ b/docs/getting-started/literature.md
@@ -30,11 +30,11 @@ Although these are significantly lower quality, not all manga get official digit
 
 [CDisplayEx](https://www.cdisplayex.com/) (Highest Quality)
 
-- Standalone reader that requires you to bring your own manga, provides the [highest quality](https://slow.pics/c/y737QBlP) scaling available on PC with [Resizing Algorithm set to Lanczos](https://i.imgur.com/BiNvbSq.png), and the [Lanczos slider set to level 2](https://i.imgur.com/qkSifGM.png).
+- Standalone reader that requires you to bring your own manga, provides the [highest quality](https://slow.pics/c/y737QBlP) scaling available on PC with [Resizing Algorithm set to Lanczos](https://user-images.githubusercontent.com/78981416/233718226-57d36d09-fe1d-40bb-b1d6-415c66272d74.png), and the [Lanczos slider set to level 2](https://user-images.githubusercontent.com/78981416/233718286-67f29d7f-53bf-47df-a41a-24fcd96a66f7.png).
 
-- For laptops or high resolution displays, you will likely need to [disable Windows DPI scaling](https://i.imgur.com/PkjLdAA.png) (Go to `C:\Program Files\CDisplayEx`, right click `CDisplayEx.exe` and select Properties -> Compatibility -> Change high DPI settings
+- For laptops or high resolution displays, you will likely need to [disable Windows DPI scaling](https://user-images.githubusercontent.com/78981416/233718346-e66ff623-abcf-4c3a-8541-23fb840e65c9.png). Go to `C:\Program Files\CDisplayEx`, right click `CDisplayEx.exe` and select Properties -> Compatibility -> Change high DPI settings
 
-- Offers an ["Auto Colors"](https://i.imgur.com/qCEc9MB.png) option which allows you to fix black levels, however requires manual tweaking depending on the source. Should only be enabled when [obvious blacks are appearing as grey](https://i.imgur.com/AA85Knn.png), at which point you should increase the white level sensitivity slightly [until they become black](https://i.imgur.com/sDmx0b7.png).
+- Offers an ["Auto Colors"](https://user-images.githubusercontent.com/78981416/233718417-d994059b-b18d-4fa1-92cf-e2f7a51bd072.png) option which allows you to fix black levels, however requires manual tweaking depending on the source. Should only be enabled when [obvious blacks are appearing as grey](https://user-images.githubusercontent.com/78981416/233718453-c358222b-384e-45f5-9ff5-151aad32c94f.png), at which point you should increase the white level sensitivity slightly [until they become black](https://user-images.githubusercontent.com/78981416/233718539-a670d966-9ab7-4f23-8abd-a1a8f2cb93f4.png).
 
 [Tachidesk](https://github.com/Suwayomi/Tachidesk-Server) (Most Convenient)
 
@@ -44,7 +44,7 @@ Although these are significantly lower quality, not all manga get official digit
 
 [Perfect Viewer](https://play.google.com/store/apps/details?id=com.rookiestudio.perfectviewer) (Highest Quality)
 
-- Standalone reader that requires you to bring your own manga, provides the [highest quality](https://slow.pics/c/y737QBlP) scaling available on Android with Image smooth filter set to [Lanczos 3](https://i.imgur.com/M2fkp9p.jpeg)
+- Standalone reader that requires you to bring your own manga, provides the [highest quality](https://slow.pics/c/y737QBlP) scaling available on Android with Image smooth filter set to [Lanczos 3](https://user-images.githubusercontent.com/78981416/233718601-dbdd3303-d96a-474e-aed5-7d4c22a8e8da.png)
 
 [Tachiyomi](https://tachiyomi.org/) (Most Convenient)
 

--- a/docs/hidden/seadex-tutorial.md
+++ b/docs/hidden/seadex-tutorial.md
@@ -10,12 +10,12 @@ visibility: hidden
 
 - Go to [SeaDex](http://releases.moe/)/[Fansubber Index](http://index.fansubcar.tel) and search for the anime you want to find Best Release/Best Fansub for (In this example i will be using Absolute Duo). In case you are looking for a movie you can switch between TV Series and Movies by clicking on the corresponding buttons at the top left corner.
 
-![seadex1.png](https://i.imgur.com/qRZQ1kR.png)
+![seadex1.png](https://user-images.githubusercontent.com/78981416/233718904-6ebbc4ba-27de-4d90-9dad-6275660a9fb4.png)
 
 As You can see the Best Release for **Absolute Duo** is "**KH"**. Now go to [Nyaa](http://nyaa.si) and search for the anime in this format -
 `"{Title of Anime}"|"{Alternate Title of Anime}" + {Release Name}"` So for this example it will be `"Absolute Duo + KH"` 
 
-![seadex4.png](https://i.imgur.com/AhT2w3t.png)
-![seadex3.png](https://i.imgur.com/7XpYFSt.png)
+![seadex4.png](https://user-images.githubusercontent.com/78981416/233718975-59e0424e-abfb-4560-a74a-f06f6d0e089e.png)
+![seadex3.png](https://user-images.githubusercontent.com/78981416/233719008-950f81ed-06ac-40ed-a76c-47d7c74d567a.png)
 
 And that's how you find Best Release/Best Fansub for the anime you are looking for. Keep in mind Seadex/Fansubber Index doesn't have every anime listed. If you cannot find the anime you are looking for in both of the index. We recommend joining our [Discord](https://discord.gg/snackbox) and asking for help there.

--- a/docs/hidden/sponsored-listing.md
+++ b/docs/hidden/sponsored-listing.md
@@ -26,13 +26,13 @@ We offer the definitive resource for users looking for new services to try out. 
 Your sponsored listing will be put up in three places, on the home page of the index for maximum traffic potential, at the top of the library overview (category) for your service, and at the top of any collections that your service is in (sub-categories).
 
 Home page:
-![nxxjegkvso.png](https://i.imgur.com/UgjHT4X.png)
+![nxxjegkvso.png](https://user-images.githubusercontent.com/78981416/233719095-22e48086-db8c-4045-924e-8e5649b23384.png)
 
 Library specific:
-![1yzcis1mlq.png](https://i.imgur.com/BpvlvEb.png)
+![1yzcis1mlq.png](https://user-images.githubusercontent.com/78981416/233719137-c6d95f5f-63c1-4d59-ac78-7560bceabff0.png)
 
 Collection specific:
-![hoar58xgky.png](https://i.imgur.com/BoGNjUv.png)
+![hoar58xgky.png](https://user-images.githubusercontent.com/78981416/233719169-5fbf36ba-587d-4773-b7cf-aaefd46230de.png)
 
 
 ## How much traffic does the index receive per month?

--- a/docs/tutorials/comparison.md
+++ b/docs/tutorials/comparison.md
@@ -156,7 +156,7 @@ If you don't want to take screenshots and upload them manually, then you can sim
 - Name the collection appropriately for Slow.pics.
 - Use a large amount of images to make the comparison as useful as possible, ideally at least 40 since you'll get a lot of futile results with it being automatic.
 - Hit `Start Upload` and patiently wait while vspreview absolutely molests your battlestation.
-  [![Comp](https://i.imgur.com/00m9QvB.png "Comp")](https://i.imgur.com/00m9QvB.png "Comp")
+  [![Comp](https://user-images.githubusercontent.com/78981416/233719219-2db98938-04f7-420b-b389-c7a3bbdf3898.png "Comp")](https://user-images.githubusercontent.com/78981416/233719219-2db98938-04f7-420b-b389-c7a3bbdf3898.png "Comp")
 
 ## Automatic Comparison Scripts
 

--- a/docs/tutorials/mpv.md
+++ b/docs/tutorials/mpv.md
@@ -91,7 +91,7 @@ apt install mpv
 The default path for mpv config is `%APPDATA%/mpv/` but a folder named `portable_config` next to the `mpv.exe` overrides this. Here's a brief overview of files/folders you may want inside either of these folders -
 
 - `mpv.conf` - MPV user settings.
-- `input.conf` - custom keybind settings. You can see the default key bindings [here](https://i.imgur.com/G6Rx74P.png) and syntax [here](https://mpv.io/manual/master/#input-conf).
+- `input.conf` - custom keybind settings. You can see the default key bindings [here](https://user-images.githubusercontent.com/78981416/233719424-c442e27d-bd40-4138-912a-746a2b14493b.png) and syntax [here](https://mpv.io/manual/master/#input-conf).
 - `fonts` - Font files in this directory are used by mpv/libass for subtitles.
 - `scripts` - This directory is used to load custom scripts, usually `.lua` files. You can find scripts [here](https://github.com/mpv-player/mpv/wiki/User-Scripts).
 - `shaders` - This directory is used to load custom shaders like NNEDI3, Ravu, FSRCNNX, etc.
@@ -157,7 +157,7 @@ Debanding is the process of removing said banding.
 
 ```
 #Banding is a visual artifact, visual artifacts should never be in a video.
-#Example of banding: https://imgur.com/32d77H0
+#Example of banding: https://user-images.githubusercontent.com/78981416/233719301-ebe72064-03ef-45ff-aa93-76ef0d990ecd.png
 #Debanding is the process of removing said banding.
 #6 minute explanation of what causes banding: https://youtu.be/h9j89L8eQQk
 

--- a/docs/tutorials/propolis.md
+++ b/docs/tutorials/propolis.md
@@ -47,7 +47,7 @@ sudo apt -y install sox flac
 2. Download the compiled release by clicking the button underneath **Download artifacts**.
 3. Extract the contents of the archive into a new folder. For the sake of this guide, I'll be extracting it to `/mnt/d/propolis-v0.5.5`
 4. Run `./propolis` in the directory you extracted propolis into and it should look like this:
-   [![./propolis](https://i.imgur.com/buzcicv.png "./propolis")](https://i.imgur.com/buzcicv.png "./propolis")
+   [![./propolis](https://user-images.githubusercontent.com/78981416/233719501-3130572b-ecd3-47ea-8c00-806a59e721c6.png "./propolis")](https://user-images.githubusercontent.com/78981416/233719501-3130572b-ecd3-47ea-8c00-806a59e721c6.png "./propolis")
    This means that you have successfully installed `propolis`.
 
 ## Adding propolis to PATH
@@ -61,4 +61,4 @@ source ~/.bashrc
 
 If you did everything correctly, `propolis` is now installed and added to path. You can test this by running `propolis` from anywhere else. For example:
 
-[![propolis](https://i.imgur.com/6FqepHA.png "propolis")](https://i.imgur.com/6FqepHA.png "propolis")
+[![propolis](https://user-images.githubusercontent.com/78981416/233719555-3593f92c-bdde-4efe-a103-1a7a21647d76.png "propolis")](https://user-images.githubusercontent.com/78981416/233719555-3593f92c-bdde-4efe-a103-1a7a21647d76.png "propolis")

--- a/docs/tutorials/sonarr.md
+++ b/docs/tutorials/sonarr.md
@@ -25,7 +25,7 @@ This guide was written for Sonarr V3, although the initial setup covered here re
 - Search `Nyaa` and add it along with any other tracker you want.
 - Launch Sonarr. It's accessible through http://localhost:8989/ by default. Go to `Left Pane -> Settings -> General -> API Key -> Copy`
 - Now go back to Prowlarr `Left Pane -> Settings -> Apps -> Add Sonarr`
-  [![Add Sonarr](https://i.imgur.com/ski3AQt.gif "Add Sonarr")](https://i.imgur.com/ski3AQt.gif "Add Sonarr")
+  [![Add Sonarr](https://user-images.githubusercontent.com/78981416/233719813-bac2be6f-2d8d-4133-94e3-2d7f8d16d340.gif "Add Sonarr")](https://user-images.githubusercontent.com/78981416/233719813-bac2be6f-2d8d-4133-94e3-2d7f8d16d340.gif "Add Sonarr")
 
 ## Sonarr
 
@@ -38,13 +38,13 @@ This guide was written for Sonarr V3, although the initial setup covered here re
   - Tag it appropriately because that's how we'll be assigning these specific Indexers to a show. No Tag means it's globally applied.
   - If they don't appear, go back to Prowlarr `Left Pane -> Settings -> Apps -> Sync App Indexers`.
   - Set the RSS interval as per the rules of the Indexer.
-    [![Indexer](https://i.imgur.com/xENPujg.png "Indexer")](https://i.imgur.com/xENPujg.png "Indexer")
+    [![Indexer](https://user-images.githubusercontent.com/78981416/233719964-cdfc24fc-b7e0-469d-86dd-31245648a14c.png "Indexer")](https://user-images.githubusercontent.com/78981416/233719964-cdfc24fc-b7e0-469d-86dd-31245648a14c.png "Indexer")
 
 ### Download Client
 
 - Go to `Settings -> Download Clients` and add your download client.
 - The Category (or tag depending on your client of choice) here is important, as this is how Sonarr identifies a download. This is what Sonarr will assign to all the downloads to keep a track of them and will not see them unless they have the specified category/tag.
-  [![Download Client](https://i.imgur.com/hfKQYcJ.png "Download Client")](https://i.imgur.com/hfKQYcJ.png "Download Client")
+  [![Download Client](https://user-images.githubusercontent.com/78981416/233720022-acf54d04-e904-4294-b798-ca9f18a4f072.png "Download Client")](https://user-images.githubusercontent.com/78981416/233720022-acf54d04-e904-4294-b798-ca9f18a4f072.png "Download Client")
 
 ### Media Management
 
@@ -63,13 +63,13 @@ Currently, Sonarr's capability of auto-downloading non-seasonal anime is quite b
 
 - We'll be making one release profile for each group or show.
 - The first release profile will be for general seasonals and grabbing [`SubsPlease`](https://nyaa.si/user/subsplease). Tag it appropriately because that's how we'll be assigning these profiles to a show. No Tag means it's globally applied.
-  [![Release Profile](https://i.imgur.com/QoLA0t8.png "SubsPlease Profile")](https://i.imgur.com/QoLA0t8.png "SubsPlease Profile")
+  [![Release Profile](https://user-images.githubusercontent.com/78981416/233720080-3273019c-a1e4-40c9-aeb4-cab0e1a6f68b.png "SubsPlease Profile")](https://user-images.githubusercontent.com/78981416/233720080-3273019c-a1e4-40c9-aeb4-cab0e1a6f68b.png "SubsPlease Profile")
 - You can make as many profiles you want for fansub releases as you want.
 - Once you are done adding all the groups you want to grab, it should look like this:
-  [![Release Profiles](https://i.imgur.com/7m6Ybgp.png "Release Profiles")](https://i.imgur.com/7m6Ybgp.png "Release Profiles")
+  [![Release Profiles](https://user-images.githubusercontent.com/78981416/233720151-0b21eb98-8df1-4d47-b751-4391fd20356a.png "Release Profiles")](https://user-images.githubusercontent.com/78981416/233720151-0b21eb98-8df1-4d47-b751-4391fd20356a.png "Release Profiles")
 - **Note:**
-  - If you want to grab a release from more than one group for a show (either based on scores, preferences or just whoever releases faster), you'll have to make a new `Release Profile` with multiple release groups in the `MUST CONTAIN` field to get the desired result ([example](https://i.imgur.com/SBpEoJQ.png)).
-  - This is because for a release to be grabbed, all the `Release Profile` tags you assign to a show must be satisfied. Assigning two profiles tags like `ly` (LostYears) and `sp` (SubsPlease) to a single show will not work because that tells Sonarr to find a release with **BOTH** words present in the folder/filename ([example](https://i.imgur.com/mXQEJrn.png)).
+  - If you want to grab a release from more than one group for a show (either based on scores, preferences or just whoever releases faster), you'll have to make a new `Release Profile` with multiple release groups in the `MUST CONTAIN` field to get the desired result ([example](https://user-images.githubusercontent.com/78981416/233720199-f0726a06-d514-40ed-bab4-bbfb51423f32.png)).
+  - This is because for a release to be grabbed, all the `Release Profile` tags you assign to a show must be satisfied. Assigning two profiles tags like `ly` (LostYears) and `sp` (SubsPlease) to a single show will not work because that tells Sonarr to find a release with **BOTH** words present in the folder/filename ([example](https://user-images.githubusercontent.com/78981416/233723608-a92e8644-f113-4b2d-84e2-2638f4d65a5e.png)).
 
 ### Adding a Seasonal Show
 
@@ -78,11 +78,11 @@ Currently, Sonarr's capability of auto-downloading non-seasonal anime is quite b
 - Check the `Start search for missing episodes` option and click the `Add` button.
 - From personal experience, it's better to use `Any` profile instead of `1080p` due to how multiple anime releasers don't bother putting `1080p` in the title, causing them to be rejected. You might also have to allow `Unknown` under `Any` profile because some releasers don't put any information in the title.
 - Set the `Series Type` to `Anime`.
-  [![Seasonal](https://i.imgur.com/0FQGR1E.gif "Seasonal")](https://i.imgur.com/0FQGR1E.gif "Seasonal")
+  [![Seasonal](https://user-images.githubusercontent.com/78981416/233724354-465d9039-c302-46ad-ad97-cfd87f9255d9.gif "Seasonal")](https://user-images.githubusercontent.com/78981416/233724354-465d9039-c302-46ad-ad97-cfd87f9255d9.gif "Seasonal")
 - It'll now show up in your client along with the `tv-sonarr` tag and Sonarr will import a hardlinked copy into the Root Folder (`/HDD/plex/anime`).
-  [![Qbit](https://i.imgur.com/271wNmN.png "Qbit")](https://i.imgur.com/271wNmN.png "Qbit")
+  [![Qbit](https://user-images.githubusercontent.com/78981416/233724402-7fc251e6-0500-47ff-abff-36d03588b508.png "Qbit")](https://user-images.githubusercontent.com/78981416/233724402-7fc251e6-0500-47ff-abff-36d03588b508.png "Qbit")
 - Your new folder structure should look like this:
-  [![Folder](https://i.imgur.com/bmmGs6i.png "Folder")](https://i.imgur.com/bmmGs6i.png "Folder")
+  [![Folder](https://user-images.githubusercontent.com/78981416/233724446-ddce4a71-d6dd-4e8a-a767-916dd11047bb.png "Folder")](https://user-images.githubusercontent.com/78981416/233724446-ddce4a71-d6dd-4e8a-a767-916dd11047bb.png "Folder")
 
 ### Downloading Complete Seasons/Shows
 
@@ -91,7 +91,7 @@ Currently, Sonarr's capability of auto-downloading non-seasonal anime is quite b
 - We will manually pick a release and then import it through Sonarr for organizing.
 - (Optional) Head over to [SeaDex](https://releases.moe) to grab the best release.
 - You can do this by simply navigating to your handpicked release's folder via `Left Pane -> Wanted -> Manual Import -> Navigate to the folder containing the episodes`
-  [![Manual Import](https://i.imgur.com/UjvXrka.gif "Manual Import")](https://i.imgur.com/UjvXrka.gif "Manual Import")
+  [![Manual Import](https://user-images.githubusercontent.com/78981416/233724505-eef67a43-efcf-4275-a104-7f26ea6c6b88.gif "Manual Import")](https://user-images.githubusercontent.com/78981416/233724505-eef67a43-efcf-4275-a104-7f26ea6c6b88.gif "Manual Import")
 
 ### Hardlinks
 
@@ -101,7 +101,7 @@ Currently, Sonarr's capability of auto-downloading non-seasonal anime is quite b
 #### Check Hardlinks
 
 - For Windows, the best way to check Hardlinks is [FindLinks](https://docs.microsoft.com/en-us/sysinternals/downloads/findlinks)
-  [![Hardlinks](https://i.imgur.com/pRZwkGG.png "Hardlinks")](https://i.imgur.com/pRZwkGG.png "Hardlinks")
+  [![Hardlinks](https://user-images.githubusercontent.com/78981416/233724780-b417e80a-a74d-4e5c-8a37-0b4c00518de2.png "Hardlinks")](https://user-images.githubusercontent.com/78981416/233724780-b417e80a-a74d-4e5c-8a37-0b4c00518de2.png "Hardlinks")
 - For Linux, [TRaSH](https://trash-guides.info/) already covers [three methods to check Hardlinks](https://trash-guides.info/Hardlinks/Check-if-hardlinks-are-working/) so I won't be covering those.
 
 #### Troubleshooting


### PR DESCRIPTION
Imgur is [updating their ToS](https://help.imgur.com/hc/en-us/articles/14415587638029-Imgur-Terms-of-Service-Update-April-19-2023-) to remove all existing uploads that aren't tied to an account, which is pretty much every imgur link in this repo.