### PR TITLE
fix: typo in music.md

### DIFF
--- a/docs/getting-started/music.md
+++ b/docs/getting-started/music.md
@@ -17,13 +17,12 @@ author:
 
 ## Spectral Analysis 
 
-- Since Soulseek doesn't have strict rules regarding upconversion (lossy->lossless), many files may be of dubious quality. This can be verified through spectral analysis. A full guide for doing so along with the required software can be found [here](https://interviewfor.red/en/spectrals.html) and [here](https://erikstechcorner.com/2020/09/how-to-check-if-your-flac-files-are-really-lossless/). In summary, you are looking for frequency cutoffs like the following:
+- Since Soulseek doesn't have strict rules regarding upconversion (lossy->lossless), many files may be of dubious quality. This can be verified through spectral analysis. A full guide for doing so along with the required software can be found [here](https://interviewfor.red/en/spectrals.html) and [here}(https://erikstechcorner.com/2020/09/how-to-check-if-your-flac-files-are-really-lossless/). In summary, you are looking for frequency cutoffs like the following:
 
 
     ![](https://user-images.githubusercontent.com/124029849/243498651-0193fe75-9a98-462d-aa2e-a3079f533bc2.png)
 
-- (Recommended) Spectrogram generation can be achieved using popular audio command-line utility [SoX](https://sox.sourceforge.net/) - [here]
-  Some basic options to generate spectrograms are `sox track01.flac -n remix 1 spectrogram -x 3000 -y 513 -z 120 -w Kaiser -o "track01-full.png"` and 
+- (Recommended) Spectrogram generation can be achieved using popular audio command-line utility [SoX](https://sox.sourceforge.net/). Some basic options to generate spectrograms are `sox track01.flac -n remix 1 spectrogram -x 3000 -y 513 -z 120 -w Kaiser -o "track01-full.png"` and 
   `sox track01.flac -n remix 1 spectrogram -X 500 -y 1025 -z 120 -w Kaiser -S 1:00 -d 0:02 -o "track01-zoom.png"`.
   
 - How this works in a nutshell is that the user's input audio file gets downmixed into a singular channel with `remix 1`, followed by the input track being replaced with a null file by flag `-n` (since spectrogram is a command that returns audio information and does not modify it, the audio itself isn't needed for much else). `-X,`, `-y`, and `-z` are used to specify the spectrogram's dimensions, where X is the length, y is the height (both in pixels), and z is the range in decibels. `-w Kaiser` produces the spectrogram calculated with the Kaiser window function. `-S` and `-d` are options that allow for the analysis of audio snippets, where S is the start and d is the end of the audio snippet. Finally, `-o "filename"` changes the name of the spectrogram. 


### PR DESCRIPTION
Accidentally left an open part of an unused hyperlink :sweat_smile: