### PR TITLE
feat: add new scraper site and quality comparison for streaming.md

### DIFF
--- a/docs/sourcing/streaming.md
+++ b/docs/sourcing/streaming.md
@@ -19,11 +19,11 @@ While one can choose between the numerous popular sites listed both here and on 
 
 A "scraper" is a site that takes content hosted on other sites, and puts it on their own. These are the streaming site equivalent to [manga aggregator sites](https://thewiki.moe/guides/literature#sourcing) that are mentioned in the literature page. These can lead to extensive libraries without the need for the site owners to host the content themselves, usually at the expense of video quality. By far the most commonly scraped from site is [gogoanime](https://gogoanime.lu/), so much so that most streaming sites in existence are gogoanime scrapers.
 
-**Examples of scraper sites:** [AllAnime](https://allanime.to/), [11anime](https://11anime.fr/), [5anime](https://5anime.net/), [Genoanime](https://genoanime.com/), [Animeflix](https://animeflix.sbs/)
+**Examples of scraper sites:** [AllAnime](https://allanime.to/), [Genoanime](https://genoanime.com/)
 
 A "self-hosted" site is one that actually hosts all the content on their own servers. With some exceptions, this usually means a significantly smaller selection than all the scraper sites who can utilize gogo's massive library. However, this usually also leads to better video quality that can range from a marginal improvement, to extremely significant.
 
-**Examples of self-hosted sites:** [gogoanime](https://gogoanime.lu/), [9anime](https://9anime.to), [Zoro](https://zoro.to/), [animepahe](https://animepahe.com/), [Marin](https://marin.moe/)
+**Examples of self-hosted sites:** [9anime](https://9anime.to), [animepahe](https://animepahe.com/), [Gogoanime](https://gogoanime.lu/), [Marin](https://marin.moe/), [Zoro](https://zoro.to/)
 
 ### Video Quality
 
@@ -32,10 +32,10 @@ While streaming sites offer the worst video quality in comparison to the alterna
 Some comparisons between streaming sites:
 
 - Demon Slayer (most major streaming sites and torrents) - https://slow.pics/c/pjYaqdnr
-- Fate/Zero (9anime, animepahe, gogo, tenshi, and torrents) - https://slow.pics/c/1LNZtDzm
-- Senran Kagura (gogo, animepahe, 9anime, twist, zoro, and torrents) - https://slow.pics/c/QLtX61qx
-- Dokyuu Hentai HxEros (gogoanime, animepahe, 9anime, torrents) - https://slow.pics/c/PZRxqAsh
-- Vinland Saga S2 (9anime, Zoro, Marin, torrents) - https://slow.pics/c/GjhwBwo3
+- Fate/Zero (9anime, animepahe, Gogoanime, tenshi/Marin, and torrents) - https://slow.pics/c/1LNZtDzm
+- Senran Kagura (9anime, animepahe, Gogoanime, Zoro, and torrents) - https://slow.pics/c/QLtX61qx
+- Dokyuu Hentai HxEros (9anime, animepahe, Gogoanime, torrents) - https://slow.pics/c/PZRxqAsh
+- Vinland Saga S2 (Gogoanime, Marin, torrents) - https://slow.pics/c/GjhwBwo3
 
 #### **Quality Tier List**
 

--- a/docs/sourcing/streaming.md
+++ b/docs/sourcing/streaming.md
@@ -7,7 +7,7 @@ order: -1
 
 ## Popular Streaming Sites
 
-- [gogoanime](https://gogoanime.lu/) - Self-hosted site that nearly all scraper sites source from.
+- [Gogoanime](https://gogoanime.lu/) - Self-hosted site that nearly all scraper sites source from.
 - [9anime](https://9anime.to) - Self-hosted site with a library on par with gogoanime. Marginally better quality while updating their releases to more often include fansubs and BD versions on older content.
 - [Zoro](https://zoro.to/) - Self-hosted site similar in quality to 9anime with an extensive library and is one of the only streaming sites with soft subtitles.
 
@@ -17,7 +17,7 @@ While one can choose between the numerous popular sites listed both here and on 
 
 ### Scrapers vs Self-Hosted Sites
 
-A "scraper" is a site that takes content hosted on other sites, and puts it on their own. These are the streaming site equivalent to [manga aggregator sites](https://thewiki.moe/guides/literature#sourcing) that are mentioned in the literature page. These can lead to extensive libraries without the need for the site owners to host the content themselves, usually at the expense of video quality. By far the most commonly scraped from site is [gogoanime](https://gogoanime.lu/), so much so that most streaming sites in existence are gogoanime scrapers.
+A "scraper" is a site that takes content hosted on other sites, and puts it on their own. These are the streaming site equivalent to [manga aggregator sites](https://thewiki.moe/guides/literature#sourcing) that are mentioned in the literature page. These can lead to extensive libraries without the need for the site owners to host the content themselves, usually at the expense of video quality. By far the most commonly scraped from site is [Gogoanime](https://gogoanime.lu/), so much so that most streaming sites in existence are gogoanime scrapers.
 
 **Examples of scraper sites:** [AllAnime](https://allanime.to/), [Genoanime](https://genoanime.com/), [YugenAnime](https://yugenanime.tv/)
 
@@ -53,7 +53,7 @@ Some comparisons between streaming sites:
 
 **Tier 3**:
 
-- [gogoanime](https://gogoanime.lu/) (and scrapers)
+- [Gogoanime](https://gogoanime.lu/) (and scrapers)
 - [animepahe](https://animepahe.com/) - Can be better or worse than gogoanime but with significantly smaller file size and the benefit of sourcing from good BD releases when available, like [Marin](https://marin.moe/).
 
 ### Other Factors
@@ -66,7 +66,7 @@ There are a multitude of other factors that may affect your decision in picking 
 
 **Filesize**
 
-- [animepahe](https://animepahe.com/) has some of the smallest filesizes compared to other streaming sites. [9anime's](https://9anime.to) are also relatively small compared to [gogoanime](https://gogoanime.lu/) and [Marin](https://marin.moe/).
+- [animepahe](https://animepahe.com/) has some of the smallest filesizes compared to other streaming sites. [9anime's](https://9anime.to) are also relatively small compared to [Gogoanime](https://gogoanime.lu/) and [Marin](https://marin.moe/).
 
 **UI**
 
@@ -74,7 +74,7 @@ There are a multitude of other factors that may affect your decision in picking 
 
 **Library**
 
-- [gogoanime](https://gogoanime.lu/) (and its scrapers) and [9anime](https://9anime.to) have some of the largest libraries available.
+- [Gogoanime](https://gogoanime.lu/) (and its scrapers) and [9anime](https://9anime.to) have some of the largest libraries available.
 
 **Soft Subs**
 

--- a/docs/sourcing/streaming.md
+++ b/docs/sourcing/streaming.md
@@ -19,7 +19,7 @@ While one can choose between the numerous popular sites listed both here and on 
 
 A "scraper" is a site that takes content hosted on other sites, and puts it on their own. These are the streaming site equivalent to [manga aggregator sites](https://thewiki.moe/guides/literature#sourcing) that are mentioned in the literature page. These can lead to extensive libraries without the need for the site owners to host the content themselves, usually at the expense of video quality. By far the most commonly scraped from site is [gogoanime](https://gogoanime.lu/), so much so that most streaming sites in existence are gogoanime scrapers.
 
-**Examples of scraper sites:** [AllAnime](https://allanime.to/), [Genoanime](https://genoanime.com/)
+**Examples of scraper sites:** [AllAnime](https://allanime.to/), [Genoanime](https://genoanime.com/), [YugenAnime](https://yugenanime.tv/)
 
 A "self-hosted" site is one that actually hosts all the content on their own servers. With some exceptions, this usually means a significantly smaller selection than all the scraper sites who can utilize gogo's massive library. However, this usually also leads to better video quality that can range from a marginal improvement, to extremely significant.
 
@@ -36,12 +36,13 @@ Some comparisons between streaming sites:
 - Senran Kagura (9anime, animepahe, Gogoanime, Zoro, and torrents) - https://slow.pics/c/QLtX61qx
 - Dokyuu Hentai HxEros (9anime, animepahe, Gogoanime, torrents) - https://slow.pics/c/PZRxqAsh
 - Vinland Saga S2 (Gogoanime, Marin, torrents) - https://slow.pics/c/GjhwBwo3
+- Oshi no Ko (9anime, Gogoanime, Marin, Zoro, torrents) - https://slow.pics/c/6HqApHsn
 
 #### **Quality Tier List**
 
 **Tier 1**:
 
-- [Marin](https://marin.moe/) - Contains the smallest library of all the sites but with the best quality for BD releases and good quality for seasonal content. Consistently the best overall
+- [Marin](https://marin.moe/) - Formerly tenshi; Contains the smallest library of all the sites but with the best quality for BD releases and good quality for seasonal content. Consistently the best overall
 - [AllAnime](https://allanime.to/) - Specific seasonal content belongs in Tier 1 because it is equal to SubsPlease/HorribleSubs releases making it the undisputed best quality for illegal streaming sites in these instances. Not all series are scraped from VRV though and in those instances the quality is Tier 3.
 - [AnimeDao](https://animedao.to/) - Same as above but it depends on which server you choose. Try them out and pick the one with good quality.
 


### PR DESCRIPTION
Added a new scraper to show in the examples section of streaming.md and a quality comparison using "Oshi no Ko," comparing a few streaming sites (9anime, Gogoanime, Marin, Zoro) and torrents.

Other changes include:

- Omitting inactive/obsolete sites from examples. These scrapers (11anime, 5anime, and Animeflix) no longer exist.
- Adjusting capitalization for consistency. Minor changes (i.e. "zoro" to "Zoro").
- Added a reference to Marin's former site "tenshi."
- The quality comparison using "Vinland Saga S2" does not include 9anime or Zoro due to mismatched frames. Removed as they do not exist in the slow.pics comparison. Gogo was added since it exists.