### PR TITLE
feat: redesign sourcing/streaming.md and getting-started/anime.md

### DIFF
--- a/docs/getting-started/anime.md
+++ b/docs/getting-started/anime.md
@@ -17,33 +17,35 @@ See [The Index](https://theindex.moe) for a more comprehensive list of unofficia
 *Looking for official streaming sites?* See [r/anime's list of legal streams](https://www.reddit.com/r/anime/wiki/legal_streams).
 !!!
 
-Streaming sites are generally preferred by most anime watchers as they require no additional setup and are easy-to-use while being convenient.
+Streaming sites are generally preferred by most anime watchers as they require no additional setup and are easy to use while being convenient.
 
 However, some sites will heavily compress video/audio and may have ads. *As a result, you may want to consider torrenting if you care about quality.*
 
-Aiming for compatibility, they are also unable to use efficient codecs like x265. *If data limits are a concern, torrenting x265 mini encodes may be a better option.* See the [quality comparison between mini encodes and most popular streaming sites](https://slow.pics/c/pjYaqdnr).
+Aiming for compatibility, they are also unable to use efficient codecs like x265. *If data limits are a concern, torrenting x265 mini encodes may be a better option.* See the [quality comparison between mini encodes and popular streaming sites](https://slow.pics/c/pjYaqdnr).
 
-Official streams have better quality, but are also typically larger (~1.3GB per episode for 1080p). *They can be obtained by torrenting from groups like SubsPlease, who rip untouched streams.*
+Official streams have better quality but are also typically larger (~1.3GB per episode for 1080p). *They can be obtained by torrenting from groups like SubsPlease, who rip untouched streams.*
 
 *See the [Streaming Sites](/sourcing/streaming/) sourcing guide and [Quality Guide](/guides/quality) for more information.*
 
 ## Torrenting
 
-Torrenting, while can sometimes require more setup, allow for more flexibility and accessibility for watching your shows.
+Torrenting, while can sometimes require more setup, allows for more flexibility and accessibility for watching your shows.
 
 Unlike streaming sites, releases will have better quality and access to BD releases. *Some shows will also have fansub choices, which may be preferred over official subtitles.*
 
 Torrenting requires the use of a torrent client, such as [qBittorrent](https://www.qbittorrent.org/download). Shows are shared in the form of .torrent files or magnet links, which can be found on trackers such as [Nyaa](https://nyaa.si). These are used by your torrent client to know what to download. *Download speeds are dependent on the number of seeds available and connection quality.*
 
 !!!warning
-**Downloading torrents may be illegal depending on where you live.** *To avoid receiving a copyright notice from your ISP, you may want to consider using a [VPN](/getting-started/torrenting#vpn) or a [seedbox](/guides/torrenting#what-is-a-seedbox).*
+**Downloading anime torrents may be illegal depending on where you live.** *To avoid receiving a copyright notice from your ISP, you may want to consider using a [VPN](/getting-started/torrenting#vpn) or a [seedbox](/guides/torrenting#what-is-a-seedbox).*
 !!!
 
 !!!
 *Blocked from accessing torrent sites?* Try using [GoodbyeDPI](https://github.com/ValdikSS/GoodbyeDPI) or follow the [Unblock Guide](/tutorials/unblock).
 !!!
 
-*See the [Torrenting Guide](/guides/torrenting) and [RSS Tutorial](/tutorials/rss) for more information.*
+Additionally, you may choose to automatically fetch and download shows using RSS or Sonarr. *Check out the [RSS Tutorial](/tutorials/rss) on how to set up RSS with your torrent client.*
+
+*See the [Torrenting Guide](/guides/torrenting) for more information.*
 
 ## Playback
 
@@ -70,5 +72,7 @@ A brief list of recommended media player applications.
 - [Jellyfin](https://jellyfin.org)
 - [Kodi](https://kodi.tv)
 - [Plex](https://www.plex.tv)
+
+===
 
 *See the [Playback Guide](/guides/playback) for more information.*

--- a/docs/getting-started/anime.md
+++ b/docs/getting-started/anime.md
@@ -9,40 +9,66 @@ image: https://user-images.githubusercontent.com/78981416/215166522-1d7358e8-bec
 
 ## Streaming
 
-Unofficial - [TheIndex](https://theindex.moe/)
+!!!
+See [The Index](https://theindex.moe) for a more comprehensive list of unofficial anime streaming sites.
+!!!
 
-Official - [/r/anime list of legal streams](https://www.reddit.com/r/anime/wiki/legal_streams)
+!!!secondary
+*Looking for official streaming sites?* See [r/anime's list of legal streams](https://www.reddit.com/r/anime/wiki/legal_streams).
+!!!
 
-Streaming sites require no setup and are convenient. However, they heavily compress video and may have ads. Aiming for compatibility, they are also unable to use efficient codecs like x265. If data limits are a concern, torrenting x265 mini encodes from Nyaa is a better option. Here is a comparison between mini encodes and most popular streaming sites - https://slow.pics/c/pjYaqdnr.
+Streaming sites are generally preferred by most anime watchers as they require no additional setup and are easy-to-use while being convenient.
 
-Official streams have better quality, but are also larger (~1.3GB per episode for 1080p). They can be obtained by torrenting from groups like SubsPlease, who rip untouched official streams.
+However, some sites will heavily compress video/audio and may have ads. *As a result, you may want to consider torrenting if you care about quality.*
 
-Read more: [Quality Guide](/guides/quality)
+Aiming for compatibility, they are also unable to use efficient codecs like x265. *If data limits are a concern, torrenting x265 mini encodes may be a better option.* See the [quality comparison between mini encodes and most popular streaming sites](https://slow.pics/c/pjYaqdnr).
+
+Official streams have better quality, but are also typically larger (~1.3GB per episode for 1080p). *They can be obtained by torrenting from groups like SubsPlease, who rip untouched streams.*
+
+*See the [Streaming Sites](/sourcing/streaming/) sourcing guide and [Quality Guide](/guides/quality) for more information.*
 
 ## Torrenting
 
-Torrent files can be found and downloaded from trackers like [nyaa.si](https://nyaa.si). Use [GoodbyeDPI](https://github.com/ValdikSS/GoodbyeDPI) or follow this [tutorial](/tutorials/unblock) to unblock sites.
+Torrenting, while can sometimes require more setup, allow for more flexibility and accessibility for watching your shows.
 
-The downloaded .torrent file or the magnet link has to be opened in your torrent client - [qBittorrent](https://www.qbittorrent.org/download.php) for PC and [LibreTorrent](https://play.google.com/store/apps/details?id=org.proninyaroslav.libretorrent)/[Flud](https://play.google.com/store/apps/details?id=com.delphicoder.flud) for Android. After the download is complete, the torrents do not need to be removed from the client.
+Unlike streaming sites, releases will have better quality and access to BD releases. *Some shows will also have fansub choices, which may be preferred over official subtitles.*
 
-The speed is dependent on the number of seeds and their connection quality. You can connect to more seeds and improve speeds with [port forwarding](/guides/torrenting#how-to-port-forward). You may want to use a [VPN](/faq/vpn) or a [seedbox](/guides/torrenting#what-is-a-seedbox) for downloading torrents to avoid receiving a copyright infringement notice from your ISP.
+Torrenting requires the use of a torrent client, such as [qBittorrent](https://www.qbittorrent.org/download). Shows are shared in the form of .torrent files or magnet links, which can be found on trackers such as [Nyaa](https://nyaa.si). These are used by your torrent client to know what to download. *Download speeds are dependent on the number of seeds available and connection quality.*
 
-Advantages of torrents include access to more options with better quality/size ratios, and automation through RSS or Sonarr.
+!!!warning
+**Downloading torrents may be illegal depending on where you live.** *To avoid receiving a copyright notice from your ISP, you may want to consider using a [VPN](/getting-started/torrenting#vpn) or a [seedbox](/guides/torrenting#what-is-a-seedbox).*
+!!!
 
-Read more: [Torrenting Guide](/guides/torrenting), [RSS Tutorial](/tutorials/rss)
+!!!
+*Blocked from accessing torrent sites?* Try using [GoodbyeDPI](https://github.com/ValdikSS/GoodbyeDPI) or follow the [Unblock Guide](/tutorials/unblock).
+!!!
+
+*See the [Torrenting Guide](/guides/torrenting) and [RSS Tutorial](/tutorials/rss) for more information.*
 
 ## Playback
 
+A brief list of recommended media player applications.
+
 !!!warning
-VLC is not recommended because it displays wrong colours, introduces visual artifacts, and breaks intensive subtitles.
+**VLC is not recommended as it introduces visual artifacts, displays wrong colors, and breaks intensive subtitles.** *Use alternative media players.*
 !!!
 
-**PC:** [MPV](https://mpv.io/installation/), [MPC-HC](https://github.com/clsid2/mpc-hc/releases), [Potplayer](https://potplayer.daum.net)
+==- PC
+- [MPC-HC](https://github.com/clsid2/mpc-hc/releases)
+- [mpv](https://mpv.io/installation/)
+- [Potplayer](https://potplayer.daum.net)
 
-**Android:** [mpv-android](https://play.google.com/store/apps/details?id=is.xyz.mpv&hl=lv&gl=US), [VLC for Android](https://play.google.com/store/apps/details?id=org.videolan.vlc)
+==- Android
+- [mpv-android](https://play.google.com/store/apps/details?id=is.xyz.mpv)
+- [VLC for Android](https://play.google.com/store/apps/details?id=org.videolan.vlc)
 
-**iOS:** [Outplayer](https://apps.apple.com/us/app/outplayer/id1449923287), [VLC for iOS](https://apps.apple.com/us/app/vlc-media-player/id650377962)
+==- iOS
+- [Outplayer](https://apps.apple.com/app/outplayer/id1449923287)
+- [VLC media player](https://apps.apple.com/app/vlc-media-player/id650377962)
 
-**TV/Media Servers:** [Kodi](https://kodi.tv), [Plex](https://www.plex.tv/), [Jellyfin](https://jellyfin.org/)
+==- TV/Media Servers
+- [Jellyfin](https://jellyfin.org)
+- [Kodi](https://kodi.tv)
+- [Plex](https://www.plex.tv)
 
-Read more: [Playback Guide](/guides/playback)
+*See the [Playback Guide](/guides/playback) for more information.*

--- a/docs/getting-started/anime.md
+++ b/docs/getting-started/anime.md
@@ -11,9 +11,7 @@ image: https://user-images.githubusercontent.com/78981416/215166522-1d7358e8-bec
 
 !!!
 See [The Index](https://theindex.moe) for a more comprehensive list of unofficial anime streaming sites.
-!!!
 
-!!!secondary
 *Looking for official streaming sites?* See [r/anime's list of legal streams](https://www.reddit.com/r/anime/wiki/legal_streams).
 !!!
 
@@ -36,11 +34,7 @@ Unlike streaming sites, releases will have better quality and access to BD relea
 Torrenting requires the use of a torrent client, such as [qBittorrent](https://www.qbittorrent.org/download). Shows are shared in the form of .torrent files or magnet links, which can be found on trackers such as [Nyaa](https://nyaa.si). These are used by your torrent client to know what to download. *Download speeds are dependent on the number of seeds available and connection quality.*
 
 !!!warning
-**Downloading anime torrents may be illegal depending on where you live.** *To avoid receiving a copyright infringement notice from your ISP, you may want to consider using a [VPN](/getting-started/torrenting#vpn) or a [seedbox](/guides/torrenting#what-is-a-seedbox).*
-!!!
-
-!!!
-*Blocked from accessing torrent sites?* Try using [GoodbyeDPI](https://github.com/ValdikSS/GoodbyeDPI) or follow the [Unblock Guide](/tutorials/unblock).
+Downloading anime torrents may be illegal depending on where you live. *To avoid receiving a copyright infringement notice from your ISP, you may want to consider using a [VPN](/getting-started/torrenting#vpn) or a [seedbox](/guides/torrenting#what-is-a-seedbox).*
 !!!
 
 Additionally, you may choose to automatically fetch and download shows using RSS or Sonarr. *Check out the [RSS Tutorial](/tutorials/rss) on how to set up RSS with your torrent client.*
@@ -52,7 +46,7 @@ Additionally, you may choose to automatically fetch and download shows using RSS
 A brief list of recommended media player applications.
 
 !!!warning
-**VLC is not recommended as it introduces visual artifacts, displays wrong colors, and breaks intensive subtitles.** *We suggest using alternative media players.*
+VLC is not recommended as it introduces visual artifacts, displays wrong colors, and breaks intensive subtitles. *We suggest using alternative media players.*
 !!!
 
 ==- PC

--- a/docs/getting-started/anime.md
+++ b/docs/getting-started/anime.md
@@ -19,9 +19,9 @@ See [The Index](https://theindex.moe) for a more comprehensive list of unofficia
 
 Streaming sites are generally preferred by most anime watchers as they require no additional setup and are easy to use while being convenient.
 
-However, some sites will heavily compress video/audio and may have ads. *As a result, you may want to consider torrenting if you care about quality.*
+However, some sites will heavily compress video/audio and may have ads. *We suggest using a reliable content blocker, such as [uBlock Origin](https://ublockorigin.com). Additionally, you may want to consider torrenting if you care about quality.*
 
-Aiming for compatibility, they are also unable to use efficient codecs like x265. *If data limits are a concern, torrenting x265 mini encodes may be a better option.* See the [quality comparison between mini encodes and popular streaming sites](https://slow.pics/c/pjYaqdnr).
+Aiming for compatibility, they are also unable to use efficient codecs like x265. *If data limits are a concern, torrenting x265 mini encodes may be a better option. See the [quality comparison between mini encodes and popular streaming sites](https://slow.pics/c/pjYaqdnr).*
 
 Official streams have better quality but are also typically larger (~1.3GB per episode for 1080p). *They can be obtained by torrenting from groups like SubsPlease, who rip untouched streams.*
 
@@ -36,7 +36,7 @@ Unlike streaming sites, releases will have better quality and access to BD relea
 Torrenting requires the use of a torrent client, such as [qBittorrent](https://www.qbittorrent.org/download). Shows are shared in the form of .torrent files or magnet links, which can be found on trackers such as [Nyaa](https://nyaa.si). These are used by your torrent client to know what to download. *Download speeds are dependent on the number of seeds available and connection quality.*
 
 !!!warning
-**Downloading anime torrents may be illegal depending on where you live.** *To avoid receiving a copyright notice from your ISP, you may want to consider using a [VPN](/getting-started/torrenting#vpn) or a [seedbox](/guides/torrenting#what-is-a-seedbox).*
+**Downloading anime torrents may be illegal depending on where you live.** *To avoid receiving a copyright infringement notice from your ISP, you may want to consider using a [VPN](/getting-started/torrenting#vpn) or a [seedbox](/guides/torrenting#what-is-a-seedbox).*
 !!!
 
 !!!
@@ -52,7 +52,7 @@ Additionally, you may choose to automatically fetch and download shows using RSS
 A brief list of recommended media player applications.
 
 !!!warning
-**VLC is not recommended as it introduces visual artifacts, displays wrong colors, and breaks intensive subtitles.** *Use alternative media players.*
+**VLC is not recommended as it introduces visual artifacts, displays wrong colors, and breaks intensive subtitles.** *We suggest using alternative media players.*
 !!!
 
 ==- PC

--- a/docs/getting-started/anime.md
+++ b/docs/getting-started/anime.md
@@ -29,12 +29,12 @@ Official streams have better quality but are also typically larger (~1.3GB per e
 
 Torrenting, while can sometimes require more setup, allows for more flexibility and accessibility for watching your shows.
 
-Unlike streaming sites, releases will have better quality and access to BD releases. *Some shows will also have fansub choices, which may be preferred over official subtitles.*
+Unlike streaming sites, torrents provide access to better releases, such as [BDs for older shows](/guides/quality/#bd-vs-web) and greater video quality. *Some shows will also have fansubs, which may be preferred over official subtitles.*
 
 Torrenting requires the use of a torrent client, such as [qBittorrent](https://www.qbittorrent.org/download). Shows are shared in the form of .torrent files or magnet links, which can be found on trackers such as [Nyaa](https://nyaa.si). These are used by your torrent client to know what to download. *Download speeds are dependent on the number of seeds available and connection quality.*
 
 !!!warning
-Downloading anime torrents may be illegal depending on where you live. *To avoid receiving a copyright infringement notice from your ISP, you may want to consider using a [VPN](/getting-started/torrenting#vpn) or a [seedbox](/guides/torrenting#what-is-a-seedbox).*
+Downloading anime torrents may be illegal depending on where you live. *To avoid receiving a copyright infringement notice from your ISP, you may want to consider using a [VPN](/getting-started/torrenting#vpn) or [seedbox](/guides/torrenting#what-is-a-seedbox).*
 !!!
 
 Additionally, you may choose to automatically fetch and download shows using RSS or Sonarr. *Check out the [RSS Tutorial](/tutorials/rss) on how to set up RSS with your torrent client.*

--- a/docs/sourcing/streaming.md
+++ b/docs/sourcing/streaming.md
@@ -5,7 +5,7 @@ order: -1
 
 # Streaming Sites
 
-!!!warning 
+!!!warning
 **Majority of unofficial streaming sites will contain unwanted or annoying pop-ups and ads that may interfere with your experience.** *We suggest you use a reliable content blocker such as [uBlock Origin](https://ublockorigin.com).*
 !!!
 
@@ -27,10 +27,10 @@ See [The Index](https://theindex.moe) for a more comprehensive list of unofficia
 
 The best way to pick a streaming site is to choose one that suits your needs and preferences. These are some factors that you may want to take into consideration:
 
-### Scrapers vs Self-Hosted Sites
+### Scrapers vs. Self-Hosted Sites
 
 !!!warning
-**Beware of fake streaming sites!** These are scrapers with copied interfaces and are often times not reflected of the original site. *Always pay attention to the URL of the website.*
+**Beware of fake streaming sites!** These are scrapers with copied interfaces and are oftentimes not reflected of the original site. *Always pay attention to the URL of the website.*
 
 You can always find legitimate sites on [The Index](https://theindex.moe).
 !!!
@@ -70,7 +70,7 @@ You can see for yourself in the quality comparisons linked below:
 
 === Tier 1 (Best)
 - [AllAnime](https://allanime.to) - Scraper site with great video quality when scraped from VRV, making them on par with SubsPlease/HorribleSubs torrent releases. *However, not all shows use VRV, resulting in Tier 3 quality.*
-- [AnimeDao](https://animedao.to) - Quality can be similar to [Allanime](https://allanime.to) depending on the server you choose.
+- [AnimeDao](https://animedao.to) - Quality can be similar to [AllAnime](https://allanime.to) depending on the server you choose.
 - [Marin](https://marin.moe) - Consistently the best video quality with BD releases and good quality for seasonals. *Formerly tenshi.*
 
 === Tier 2 (Good)
@@ -103,10 +103,10 @@ There are a multitude of other factors that may affect your decision in picking 
 Additionally, [9anime](https://9anime.to) has one of the best libraries when it comes to older and rarer shows.
 
 ==- Soft Subs
-[Zoro](https://zoro.to) is one of the only streaming sites that uses soft subtitles, with the other alternatives being legal streaming sites.
+[Zoro](https://zoro.to) is one of the only streaming sites that use soft subtitles, with the other alternatives being legal streaming sites.
 
 ==- UI and Features
-Users often care about the UI and site features. As this is completely subjective, we suggest you visit and try out the collection of sites from [The Index](https://theindex.moe) and find what you like best.
+Users often care about the UI and site features. *As this is completely subjective, we suggest you visit and try out the collection of sites from [The Index](https://theindex.moe) and find what you like best.*
 
 ===
 

--- a/docs/sourcing/streaming.md
+++ b/docs/sourcing/streaming.md
@@ -6,22 +6,18 @@ order: -1
 # Streaming Sites
 
 !!!warning
-**Majority of unofficial streaming sites will contain unwanted or annoying pop-ups and ads that may interfere with your experience.** *We suggest you use a reliable content blocker such as [uBlock Origin](https://ublockorigin.com).*
+Majority of unofficial streaming sites will contain unwanted or annoying pop-ups and ads that may interfere with your experience. *We suggest you use a reliable content blocker such as [uBlock Origin](https://ublockorigin.com).*
 !!!
 
 ## Popular Sites
 
-!!!
-See [The Index](https://theindex.moe) for a more comprehensive list of unofficial anime streaming sites.
-!!!
-
-!!!secondary
-*Looking for official streaming sites?* See [r/anime's list of legal streams](https://www.reddit.com/r/anime/wiki/legal_streams).
-!!!
-
 - [9anime](https://9anime.to) - Self-hosted site with one of the largest and oldest anime libraries. *Releases are often updated to include fansubs and BD releases for older content.*
 - [Gogoanime](https://gogoanime.lu) - Self-hosted site with a vast library. *Majority of scraper sites will source from here.*
 - [Zoro](https://zoro.to) - Self-hosted site with quality similar to 9anime while maintaining an extensive library. *One of the only streaming sites with soft subtitles.*
+
+See [The Index](https://theindex.moe) for a more comprehensive list of unofficial anime streaming sites.
+
+*Looking for official streaming sites?* See [r/anime's list of legal streams](https://www.reddit.com/r/anime/wiki/legal_streams).
 
 ## Picking a Site
 
@@ -30,9 +26,9 @@ The best way to pick a streaming site is to choose one that suits your needs and
 ### Scrapers vs. Self-Hosted Sites
 
 !!!warning
-**Beware of fake streaming sites!** These are scrapers with copied interfaces and are oftentimes not reflected of the original site. *Always pay attention to the URL of the website.*
+Beware of fake streaming sites! *These are scrapers with copied interfaces and are oftentimes not reflected of the original site. Always pay attention to the URL of the website.*
 
-You can always find legitimate sites on [The Index](https://theindex.moe).
+*You can always find legitimate sites on [The Index](https://theindex.moe).*
 !!!
 
 ==- Scraper Sites
@@ -110,6 +106,4 @@ Users often care about the UI and site features. *As this is completely subjecti
 
 ===
 
-!!!
-Additional factors, like the ability to download, comment, use [MAL-Sync](https://malsync.moe), and more can be identified in [The Index](https://theindex.moe).
-!!!
+*Additional factors, like the ability to download, comment, use [MAL-Sync](https://malsync.moe), and more can be identified in [The Index](https://theindex.moe).*

--- a/docs/sourcing/streaming.md
+++ b/docs/sourcing/streaming.md
@@ -5,79 +5,111 @@ order: -1
 
 # Streaming Sites
 
-## Popular Streaming Sites
+!!!warning 
+**Majority of unofficial streaming sites will contain unwanted or annoying pop-ups and ads that may interfere with your experience.** *We suggest you use a reliable content blocker such as [uBlock Origin](https://ublockorigin.com).*
+!!!
 
-- [Gogoanime](https://gogoanime.lu/) - Self-hosted site that nearly all scraper sites source from.
-- [9anime](https://9anime.to) - Self-hosted site with a library on par with gogoanime. Marginally better quality while updating their releases to more often include fansubs and BD versions on older content.
-- [Zoro](https://zoro.to/) - Self-hosted site similar in quality to 9anime with an extensive library and is one of the only streaming sites with soft subtitles.
+## Popular Sites
 
-## Picking a Streaming Site
+!!!
+See [The Index](https://theindex.moe) for a more comprehensive list of unofficial anime streaming sites.
+!!!
 
-While one can choose between the numerous popular sites listed both here and on [The Index](https://theindex.moe/), the best way to pick a streaming site is to choose one that suits your needs, whatever those may be. These are some factors that may affect your choice.
+!!!secondary
+*Looking for official streaming sites?* See [r/anime's list of legal streams](https://www.reddit.com/r/anime/wiki/legal_streams).
+!!!
+
+- [9anime](https://9anime.to) - Self-hosted site with one of the largest and oldest anime libraries. *Releases are often updated to include fansubs and BD releases for older content.*
+- [Gogoanime](https://gogoanime.lu) - Self-hosted site with a vast library. *Majority of scraper sites will source from here.*
+- [Zoro](https://zoro.to) - Self-hosted site with quality similar to 9anime while maintaining an extensive library. *One of the only streaming sites with soft subtitles.*
+
+## Picking a Site
+
+The best way to pick a streaming site is to choose one that suits your needs and preferences. These are some factors that you may want to take into consideration:
 
 ### Scrapers vs Self-Hosted Sites
 
-A "scraper" is a site that takes content hosted on other sites, and puts it on their own. These are the streaming site equivalent to [manga aggregator sites](https://thewiki.moe/guides/literature#sourcing) that are mentioned in the literature page. These can lead to extensive libraries without the need for the site owners to host the content themselves, usually at the expense of video quality. By far the most commonly scraped from site is [Gogoanime](https://gogoanime.lu/), so much so that most streaming sites in existence are gogoanime scrapers.
+!!!warning
+**Beware of fake streaming sites!** These are scrapers with copied interfaces and are often times not reflected of the original site. *Always pay attention to the URL of the website.*
 
-**Examples of scraper sites:** [AllAnime](https://allanime.to/), [Genoanime](https://genoanime.com/), [YugenAnime](https://yugenanime.tv/)
+You can always find legitimate sites on [The Index](https://theindex.moe).
+!!!
 
-A "self-hosted" site is one that actually hosts all the content on their own servers. With some exceptions, this usually means a significantly smaller selection than all the scraper sites who can utilize gogo's massive library. However, this usually also leads to better video quality that can range from a marginal improvement, to extremely significant.
+==- Scraper Sites
+A **scraper** is a site that grabs content hosted on existing self-hosted sites and uses it for their own site, similar to how manga aggregator sites operate.
 
-**Examples of self-hosted sites:** [9anime](https://9anime.to), [animepahe](https://animepahe.com/), [Gogoanime](https://gogoanime.lu/), [Marin](https://marin.moe/), [Zoro](https://zoro.to/)
+This allows for anime libraries equivalent in size to self-hosted ones, without the need for the scraper to host content themselves. Additionally, site owners can implement their own UI or features, which may be preferred over the original site.
+
+Majority of sites will scrape from [Gogoanime](https://gogoanime.lu), a popular self-hosted streaming site.
+
+**Examples of scraper sites:** [AllAnime](https://allanime.to), [Anix](https://anix.to), [Genoanime](https://genoanime.com), [YugenAnime](https://yugenanime.tv)
+
+==- Self-Hosted Sites
+A **self-hosted** site is a streaming site that hosts the content on their own servers.
+
+Typically, self-hosted sites allow for significantly better video quality compared to scrapers or other sites. They also generally pick good BD releases or fansubs for some shows. *However, some self-hosted libraries can be more limited.*
+
+**Examples of self-hosted sites:** [9anime](https://9anime.to), [animepahe](https://animepahe.com), [Gogoanime](https://gogoanime.lu), [Marin](https://marin.moe), [Zoro](https://zoro.to)
+
+===
 
 ### Video Quality
 
-While streaming sites offer the worst video quality in comparison to the alternatives such as torrenting, DDL, or XDCC, that does not mean that all streaming sites are made equal. If for whatever reason those other methods are not open to you but you'd still like to improve the video quality of your media, then you have some options available to you.
+While streaming sites will offer worse video quality compared to alternatives such as torrenting, DDL, XDCC, or even legal streaming, *not all streaming sites are made equal.*
 
-Some comparisons between streaming sites:
+You can see for yourself in the quality comparisons linked below:
 
-- Demon Slayer (most major streaming sites and torrents) - https://slow.pics/c/pjYaqdnr
-- Fate/Zero (9anime, animepahe, Gogoanime, tenshi/Marin, and torrents) - https://slow.pics/c/1LNZtDzm
-- Senran Kagura (9anime, animepahe, Gogoanime, Zoro, and torrents) - https://slow.pics/c/QLtX61qx
-- Dokyuu Hentai HxEros (9anime, animepahe, Gogoanime, torrents) - https://slow.pics/c/PZRxqAsh
-- Vinland Saga S2 (Gogoanime, Marin, torrents) - https://slow.pics/c/GjhwBwo3
-- Oshi no Ko (9anime, Gogoanime, Marin, Zoro, torrents) - https://slow.pics/c/6HqApHsn
+- [Demon Slayer](https://slow.pics/c/pjYaqdnr) - 9anime, animepahe, Gogoanime, tenshi (Marin), Zoro, torrents
+- [Fate/Zero](https://slow.pics/c/1LNZtDzm) - 9anime, animepahe, Gogoanime, tenshi (Marin), torrents
+- [Senran Kagura](https://slow.pics/c/QLtX61qx) - 9anime, animepahe, Gogoanime, Zoro, torrents
+- [Dokyuu Hentai HxEros](https://slow.pics/c/PZRxqAsh) - 9anime, animepahe, Gogoanime, torrents
+- [Vinland Saga S2](https://slow.pics/c/GjhwBwo3) - Gogoanime, Marin, torrents
+- [Oshi no Ko](https://slow.pics/c/6HqApHsn) - 9anime, Gogoanime, Marin, Zoro, torrents
 
-#### **Quality Tier List**
+#### Quality Tier List
 
-**Tier 1**:
+=== Tier 1 (Best)
+- [AllAnime](https://allanime.to) - Scraper site with great video quality when scraped from VRV, making them on par with SubsPlease/HorribleSubs torrent releases. *However, not all shows use VRV, resulting in Tier 3 quality.*
+- [AnimeDao](https://animedao.to) - Quality can be similar to [Allanime](https://allanime.to) depending on the server you choose.
+- [Marin](https://marin.moe) - Consistently the best video quality with BD releases and good quality for seasonals. *Formerly tenshi.*
 
-- [Marin](https://marin.moe/) - Formerly tenshi; Contains the smallest library of all the sites but with the best quality for BD releases and good quality for seasonal content. Consistently the best overall
-- [AllAnime](https://allanime.to/) - Specific seasonal content belongs in Tier 1 because it is equal to SubsPlease/HorribleSubs releases making it the undisputed best quality for illegal streaming sites in these instances. Not all series are scraped from VRV though and in those instances the quality is Tier 3.
-- [AnimeDao](https://animedao.to/) - Same as above but it depends on which server you choose. Try them out and pick the one with good quality.
-
-**Tier 2**:
-
+=== Tier 2 (Good)
 - [9anime](https://9anime.to)
-- [Zoro](https://zoro.to/)
+- [Zoro](https://zoro.to)
 
-**Tier 3**:
+=== Tier 3 (Okay)
+- [animepahe](https://animepahe.com) - Quality can be better or worse than Gogoanime. *However, they offer significantly smaller file sizes and use good BD releases whenever available similar to [Marin](https://marin.moe).*
+- [Gogoanime](https://gogoanime.lu) (and its scrapers)
 
-- [Gogoanime](https://gogoanime.lu/) (and scrapers)
-- [animepahe](https://animepahe.com/) - Can be better or worse than gogoanime but with significantly smaller file size and the benefit of sourcing from good BD releases when available, like [Marin](https://marin.moe/).
+===
 
 ### Other Factors
 
-There are a multitude of other factors that may affect your decision in picking a site. Here are some brief recommendations based on some factors that aren't covered in [The Index](https://theindex.moe/) and are often not taken into account.
+There are a multitude of other factors that may affect your decision in picking a site. Here are some brief recommendations based on some factors that aren't covered in [The Index](https://theindex.moe) and are often not taken into account:
 
-**Fansubs and BD Versions**
+==- Fansubs and BD Releases
+[Marin](https://marin.moe) and [animepahe](https://animepahe.com) are very consistent at picking good BD releases with fansubs. 
 
-- [Marin](https://marin.moe/) and [animepahe](https://animepahe.com/) are very consistent at picking good BD releases with good fansubs. [9anime](https://9anime.to) also does this but less often and often with slightly worse release choice.
+[9anime](https://9anime.to) does this too, *but typically less often and with slightly worse release choice.*
 
-**Filesize**
+==- File Size
+[animepahe](https://animepahe.com) has some of the smallest file sizes compared to other streaming sites.
 
-- [animepahe](https://animepahe.com/) has some of the smallest filesizes compared to other streaming sites. [9anime's](https://9anime.to) are also relatively small compared to [Gogoanime](https://gogoanime.lu/) and [Marin](https://marin.moe/).
+[9anime's](https://9anime.to) are also relatively small when compared to sites like [Gogoanime](https://gogoanime.lu) and [Marin](https://marin.moe).
 
-**UI**
+==- Library
+[9anime](https://9anime.to) and [Gogoanime](https://gogoanime.lu) have some of the largest libraries available.
 
-- Streaming site users often care about the UI and user experience. This is completely subjective, and the best advice we have is to try out the sites from [The Index](https://theindex.moe/) yourself and find what you like.
+Additionally, [9anime](https://9anime.to) has one of the best libraries when it comes to older and rarer shows.
 
-**Library**
+==- Soft Subs
+[Zoro](https://zoro.to) is one of the only streaming sites that uses soft subtitles, with the other alternatives being legal streaming sites.
 
-- [Gogoanime](https://gogoanime.lu/) (and its scrapers) and [9anime](https://9anime.to) have some of the largest libraries available.
+==- UI and Features
+Users often care about the UI and site features. As this is completely subjective, we suggest you visit and try out the collection of sites from [The Index](https://theindex.moe) and find what you like best.
 
-**Soft Subs**
+===
 
-- [Zoro](https://zoro.to/) is one of the only streaming sites with soft subtitles with the only other real alternatives being legal streaming sites.
-
-Other factors like the ability to download, commments, MAL-Sync, and more can be identified in [The Index](https://theindex.moe/)
+!!!
+Additional factors, like the ability to download, comment, use [MAL-Sync](https://malsync.moe), and more can be identified in [The Index](https://theindex.moe).
+!!!


### PR DESCRIPTION
Redesign for sourcing/streaming.md and getting-started/anime.md to simplify information and utilize Retype's components for a more organized look.

Majority of the documentation was rewritten to make it easier to understand for the user, while also maintaining a similar or better level of information.

Some other changes include:
- Reducing information that isn't necessary in anime.md, directing users to the main page if they wish to learn more.
- Fixing links to pages that have been moved or removed.
- Recommending the user a reliable content/ad blocker in streaming.md and anime.md.
- Warnings (i.e. copyright notices through torrenting, fake streaming sites).
- Amending grammatical and formatting errors.

[These changes can be previewed live here.](https://ricky8k.github.io/thewiki/)