### PR TITLE
feat: add `Neutral leech` to glossary

### DIFF
--- a/docs/resources/glossary.md
+++ b/docs/resources/glossary.md
@@ -51,6 +51,7 @@ order: -4
 | Buffer          | The difference between the amount of data a user has uploaded and downloaded on a private tracker                                                                                                  |
 | DHT             | A decentralized method used by BitTorrent to track peers without relying on a central server, enabling peer discovery and file sharing even if the tracker is unavailable                          |
 | Freeleech       | A status assigned to certain torrents on a private tracker where the downloaded data does not count towards a user's download ratio, encouraging increased participation and sharing               |
+| Neutral leech   | A status assigned to certain torrents on a private tracker where none of the data uploaded or downloaded is counted                                                                                |     
 | Hit and run     | A term used to describe when a user downloads a file from a private tracker but fails to continue seeding it to the required ratio or for a specified period                                       |
 | Leecher         | A user who is in the process of downloading a file but has not yet completed the download or is not actively uploading (sharing) the downloaded pieces with others                                 |
 | Magnet link     | A type of hyperlink used in BitTorrent that allows users to directly connect to the tracker and peers without needing to download a separate torrent file                                          |


### PR DESCRIPTION
I added the definition for neutral leech.