### PR TITLE
feat: redesign guides/playback.md

### DIFF
--- a/docs/getting-started/anime.md
+++ b/docs/getting-started/anime.md
@@ -46,27 +46,32 @@ Additionally, you may choose to automatically fetch and download shows using RSS
 A brief list of recommended media player applications.
 
 !!!warning
-VLC is not recommended as it introduces visual artifacts, displays wrong colors, and breaks intensive subtitles. *We suggest using alternative media players.*
+VLC is not recommended as it introduces visual artifacts, displays wrong colors, and breaks intensive subtitles. We suggest using alternative media players.
 !!!
 
-==- PC
++++ PC :desktop_computer:
+
+- [mpv](https://mpv.io/installation/) [!badge variant="info" text="Recommended"]
 - [MPC-HC](https://github.com/clsid2/mpc-hc/releases)
-- [mpv](https://mpv.io/installation/)
 - [Potplayer](https://potplayer.daum.net)
 
-==- Android
-- [mpv-android](https://play.google.com/store/apps/details?id=is.xyz.mpv)
++++ Android :robot_face:
+
+- [mpv-android](https://play.google.com/store/apps/details?id=is.xyz.mpv) [!badge variant="info" text="Recommended"]
 - [VLC for Android](https://play.google.com/store/apps/details?id=org.videolan.vlc)
 
-==- iOS
++++ iOS :green_apple:
+
 - [Outplayer](https://apps.apple.com/app/outplayer/id1449923287)
 - [VLC media player](https://apps.apple.com/app/vlc-media-player/id650377962)
 
-==- TV/Media Servers
-- [Jellyfin](https://jellyfin.org)
-- [Kodi](https://kodi.tv)
-- [Plex](https://www.plex.tv)
++++ TV/Media Servers :tv:
 
-===
+- [Kodi](https://kodi.tv) [!badge variant="info" text="Recommended"]
+- [Plex](https://www.plex.tv) [!badge variant="info" text="Recommended"]
+- [Emby](https://emby.media)
+- [Jellyfin](https://jellyfin.org)
+
++++
 
 *See the [Playback Guide](/guides/playback) for more information.*

--- a/docs/guides/playback.md
+++ b/docs/guides/playback.md
@@ -11,13 +11,13 @@ image: https://user-images.githubusercontent.com/78981416/215166522-1d7358e8-bec
 
 +++ PC :desktop_computer:
 
-- [mpv](https://mpv.io/installation/) (Recommended) - [Installation and configuration tutorial](/tutorials/mpv)
+- [mpv](https://mpv.io/installation/) [!badge Recommended] - [Installation and configuration tutorial](/tutorials/mpv)
 - [MPC-HC](https://github.com/clsid2/mpc-hc/releases) - [Configuration guide with madVR](https://kokomins.wordpress.com/2021/03/27/mpc-hc-and-madvr-setup-guide/)
 - [Potplayer](https://potplayer.daum.net)
 
 +++ Android :robot_face:
 
-- [mpv-android](https://play.google.com/store/apps/details?id=is.xyz.mpv) (Recommended)
+- [mpv-android](https://play.google.com/store/apps/details?id=is.xyz.mpv) [!badge Recommended]
 - [VLC for Android](https://play.google.com/store/apps/details?id=org.videolan.vlc)
 
 +++ iOS :green_apple:
@@ -27,16 +27,16 @@ image: https://user-images.githubusercontent.com/78981416/215166522-1d7358e8-bec
 
 +++ TV/Media Servers :tv:
 
-- [Plex](https://www.plex.tv)
-- [Kodi](https://kodi.tv) - *Can be installed optionally through [LibreELEC OS](https://libreelec.tv).*
-- [Jellyfin](https://jellyfin.org)
+- [Kodi](https://kodi.tv) [!badge Recommended] - *Can be installed optionally through [LibreELEC OS](https://libreelec.tv).*
+- [Plex](https://www.plex.tv) [!badge Recommended]
 - [Emby](https://emby.media)
+- [Jellyfin](https://jellyfin.org)
 
 +++
 
 !!!warning
 VLC is not recommended as it introduces visual artifacts, displays wrong colors, and breaks intensive subtitles. We suggest using alternative media players.
-See the example comparisons to mpv: [Spice and Wolf](https://slow.pics/c/XhbmrYgU), [One Piece](https://slow.pics/c/FW2nBwKP)
+*See the example comparisons to mpv: [Spice and Wolf](https://slow.pics/c/XhbmrYgU), [One Piece](https://slow.pics/c/FW2nBwKP)*
 !!!
 
 ## Media Servers
@@ -48,7 +48,9 @@ The setup consists of two parts: the **server** and the **client**. *Both may be
 
 In a typical setup, the server is installed on a computer hosted on your home network, with the client being installed on all your devices. Most media players will also come with their own client, as well as including support for using [Kodi](https://kodi.tv) as a client (recommended for anime).
 
-- [Emby](https://emby.media) - [Plex](https://www.plex.tv) - [Jellyfin](https://jellyfin.org)
+[!button variant="info" text="Emby" margin="0 8 0 0"](https://emby.media)
+[!button variant="info" text="Plex" margin="0 8 0 0"](https://www.plex.tv)
+[!button variant="info" text="Jellyfin"](https://jellyfin.org)
 
 !!!
 Running a media server requires a rigid folder structure and a specific file naming scheme.
@@ -61,11 +63,9 @@ Running a media server requires a rigid folder structure and a specific file nam
 
 There are three ways of installing and configuring Kodi for your TV:
 
-**Basic:** Kodi client on your computer, with content also stored on your computer.
-
-**Intermediate:** Kodi client on a TV/Android Box, with content stored on your computer.
-
-Com**Plex:** Kodi client on a TV/Android Box, with content stored on a media server.
+- **Basic:** Kodi client on your computer, with content also stored on your computer.
+- **Intermediate:** Kodi client on a TV/Android Box, with content stored on your computer.
+- Com**Plex:** Kodi client on a TV/Android Box, with content stored on a media server.
 
 +++ Basic
 
@@ -110,7 +110,7 @@ For displays that match the content resolution you will only see chroma scaling,
 [mpv](https://mpv.io) has a built-in high-quality profile called `gpu-hq` which enables better upscaling algorithms (`scale=spline36`, `cscale=spline36`, `dscale=mitchell`). By default, mpv uses `spline36`. *This option is necessary to enable even if you use an external shader, as it can act as a fallback.*
 
 !!!
-`gpu-hq` enables debanding by default, which is not recommend for high quality sources. It should be followed by `deband=no`.
+`gpu-hq` enables debanding by default, which is not recommended for high-quality sources. It should be followed by `deband=no`.
 !!!
 
 #### Recommended Shaders
@@ -178,7 +178,7 @@ A 60Hz monitor can refresh up to 60 frames every second. Thus, if you were to pl
 - 30 fps: 1 frame is shown for *every 2 refreshes* (next frame in 33.33 ms).
 - 15 fps: 1 frame is shown for *every 4 refreshes* (next frame in 66.67 ms).
 
-These frame rates work because they divide evenly into the monitor's 60Hz refresh rate. *With 60 fps video, for instance, each frame is shown per refresh on a 60Hz monitor, with the next frame always appearing 16.67 ms later than the first.*
+These frame rates work because they divide evenly into the monitor's 60Hz refresh rate. With 60 fps video, for instance, each frame is shown per refresh on a 60Hz monitor, with the next frame always appearing 16.67 ms later than the first.
 
 When content plays at 24 fps, your monitor will need to show 1 frame for every 2.5 refreshes (60Hz divided by 24 fps). *However, refreshes cannot be divided, and you cannot have "part" of a refresh show on your monitor without screen tearing.*
 
@@ -198,9 +198,7 @@ This process is repeated for the entire video. Because each frame is displayed f
 To avoid judder, it is best to try and match your display's refresh rate with the content frame rate via the following methods:
 
 +++ High Refresh Rate
-Displays that run at 120Hz, 144Hz, 240Hz, or 360Hz will match perfectly with each frame, as they are all multiples of 24.
-
-Technically they should be set as 119.88hz, 143.86hz, 239.76hz, or 359.64hz to match with the majority of content (24000/1001)fps, roughly 23.976fps
+Displays that run at 120Hz, 144Hz, 240Hz, or 360Hz will match with each frame, as they are all multiples of 24. Technically, they should be set at 119.88Hz, 143.86Hz, 239.76Hz, or 359.64Hz to perfectly match with the majority of content at 23.976 fps (24000/1001 fps).
 
 *144Hz displays will not display 30/60 fps content properly. Additionally, none of the above will handle 25 fps content correctly.*
 
@@ -211,12 +209,12 @@ Most modern GPUs will have adaptive sync functionality, such as through AMD Free
 
 The best solution is to use G-SYNC/G-SYNC Compatible or FreeSync Premium. *Normal FreeSync may work if your monitor supports [Low Framerate Compensation (LFC)](https://www.amd.com/en/technologies/free-sync-faq#faq-What-is-Low-Framerate-Compensation?). You will also need to use a media player that supports adaptive sync, such as [mpv](https://mpv.io).*
 
-You may need to force exclusive fullscreen in mpv to activate adaptive sync, this can be done by adding `ontop` & `fullscreen` to your config file. You can tell adaptive sync is working when your cursor feels laggy, as this means your display has dropped refresh rate to match the content.
+Additionally, you may need to force exclusive fullscreen to activate adaptive sync. In mpv, this can be done by adding `ontop` & `fullscreen` to your `mpv.conf` file. You can tell adaptive sync is active when your cursor feels laggy, as this means your display has dropped its refresh rate to match the content.
 
 +++ Automatic Refresh Rate Adjustment
 Many modern streaming devices (e.g. Amazon Fire TV, Apple TV, NVIDIA SHIELD, etc.) will have the option to change the TV refresh rate to match the content frame rate, either through the device's settings or a setting in the playback software (Kodi, Plex, etc.)
 
-24/30/60 fps content should all work perfectly. *25 fps content requires 25/50Hz support, which some TVs in [NTSC regions](https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/PAL-NTSC-SECAM.svg/2560px-PAL-NTSC-SECAM.svg.png) do not support.*
+24/30/60 fps content should all work perfectly. 25 fps content requires 25/50Hz support, *which some TVs in [NTSC regions](https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/PAL-NTSC-SECAM.svg/2560px-PAL-NTSC-SECAM.svg.png) do not support.*
 
 ![NTSC Regions](https://i.imgur.com/Xb0Frlb.png)
 
@@ -228,11 +226,10 @@ Many modern streaming devices (e.g. Amazon Fire TV, Apple TV, NVIDIA SHIELD, etc
 
 Decoding is the process of deciphering the encoded video into a format that your device can display.
 
-There are two ways to handle video decoding: Software (SW), and Hardware (HW)
+There are two ways to handle video decoding:
 
-**Software decoding** uses your CPU to bruteforce decode any format, and is only limited by how powerful your chip is.
-
-**Hardware decoding** is vastly more efficient as it uses dedicated decoders on your GPU, resulting in better performance, less power usage, and less strain on your CPU. However older devices will not have support for newer codecs.
+- **Software decoding** uses your CPU, allowing your system to decode any format, and is only limited by how powerful your chip is.
+- **Hardware decoding** uses dedicated decoders on your GPU, making it vastly more efficient and resulting in better performance, lower power usage, and less strain on your CPU. *However, some older devices will not support this option for newer codecs.*
 
 For most users, this isn't an issue. Generally:
 
@@ -248,7 +245,7 @@ Most TVs and boxes will display a list of supported codecs on their specificatio
 
 ### Typesetting
 
-Almost all subbed anime will use `.ass` subtitles, allowing for extensive styling and typesetting. This comes at the cost of additional system resources, though most modern computers, phones, and media servers will not have an issue.
+Almost all subbed anime will use `.ass` subtitles, as they allow for extensive styling and typesetting. This comes at the cost of additional system resources, though most modern computers, phones, and media servers will not have an issue.
 
 While subtitles will display on most TVs/media players, the typesetting or overlapping dialogue can sometimes be broken when using certain applications. *This is especially a problem with fansubs, where typesetting is used extensively in various areas (e.g. text on a sign, moving scenes).*
 

--- a/docs/guides/playback.md
+++ b/docs/guides/playback.md
@@ -1,6 +1,8 @@
 ---
 label: Playback
 order: -2
+description: Learn how to play your anime
+image: https://user-images.githubusercontent.com/78981416/215166522-1d7358e8-bec2-4a54-a9ec-71deab646e56.gif
 ---
 
 # Playback
@@ -23,7 +25,7 @@ order: -2
 ==- TV/Media Servers
 - [Emby](https://emby.media)
 - [Jellyfin](https://jellyfin.org)
-- [Kodi](https://kodi.tv) - *Can be installed optionally through [LibreElec OS](https://libreelec.tv).*
+- [Kodi](https://kodi.tv) - *Can be installed optionally through [LibreELEC OS](https://libreelec.tv).*
 - [Plex](https://www.plex.tv)
 
 ===
@@ -31,31 +33,34 @@ order: -2
 !!!warning
 VLC is not recommended as it introduces visual artifacts, displays wrong colors, and breaks intensive subtitles. *We suggest using alternative media players.*
 
-*See the example comparisons below:*
-- https://slow.pics/c/XhbmrYgU
-- https://slow.pics/c/vH560pvp
-
+*See the example comparisons to [mpv](https://mpv.io) below:*
+- [Spice and Wolf](https://slow.pics/c/XhbmrYgU)
+- [One Piece](https://slow.pics/c/FW2nBwKP)
 !!!
 
 ## Media Servers
 
-The setup consists of two parts: the **server** and the **client**. *Both may be installed on the same system, but they're separate applications.*
+The setup consists of two parts: the **server** and the **client**. *Both may be installed on the same system, but they are separate applications.*
 - The **client** is a media player that will access the content stored on the server.
 - The **server** runs on the device which hosts your content.
 
 In a typical setup, the server is installed on a computer hosted on your home network, with the client being installed on all your devices. *Most media players will also come with their own client, as well as including support for using [Kodi](https://kodi.tv) as a client (recommended for anime).*
 
 - [Emby](https://emby.media)
-- [Plex](https://www.plex.tv) - [Guide for Anime](https://docs.google.com/document/d/1sXKZDYzbBDDWS8eqJ3IcaxSWhYKIPDdtChm74CBJ6ig)
+- [Plex](https://www.plex.tv)
 - [Jellyfin](https://jellyfin.org)
 
-==- Scanning Anime Without Renaming
-- [Scanning files without renaming them](https://kodi.wiki/view/Anime#Scanning_files_without_renaming_them) [!badge Kodi]
-- [Absolute Series Scanner](https://github.com/ZeroQI/Hama.bundle) [!badge Plex]
+!!!
+Running a media server requires a rigid folder structure and a set file naming scheme.
 
-===
+*See the guides below for your server:*
+- [Jellyfin](https://jellyfin.org/docs/general/server/media/shows)
+- [Plex](https://support.plex.tv/articles/naming-and-organizing-your-movie-media-files/)
+!!!
 
 ### Kodi
+
+#### Installing Kodi
 
 There are three ways of installing and configuring Kodi for your TV:
 
@@ -80,6 +85,10 @@ Here, Kodi acts as the client, increasing compatibility and replacing the defaul
 
 ===
 
+#### Scanning Files
+
+*See [Kodi's documentation on scanning files without renaming them](https://kodi.wiki/view/Anime#Scanning_files_without_renaming_them).*
+
 ## Settings
 
 ### Scaling
@@ -90,17 +99,25 @@ Scaling is the process of taking content that does not match your screen resolut
 
 For displays that match the content resolution, scaling isn't necessary. *These shaders only activate when these resolutions don't match. Scaling is not an enhancement and cannot be enabled manually.*
 
-[mpv](https://mpv.io) has a built-in high-quality profile called `gpu-hq` which enables better upscaling algorithms (`scale=spline36`, `cscale=spline36`, `dscale=mitchell`). *This option is necessary to enable even if you use external shaders, as it can act as a fallback.*
+[mpv](https://mpv.io) has a built-in high-quality profile called `gpu-hq` which enables better upscaling algorithms (`scale=spline36`, `cscale=spline36`, `dscale=mitchell`). By default, mpv uses `spline36`. *This option is necessary to enable even if you use external shaders, as it can act as a fallback.*
 
-For those with powerful GPUs, we recommend using the following external shaders for mpv:
-- [RAVU and nnedi3](https://github.com/bjin/mpv-prescalers)
-- [FSRCNNX](https://github.com/igv/FSRCNN-TensorFlow/releases)
+#### External Shaders
 
-These are 2x shaders, meaning they always scale by 2x, regardless of the original video. For instance, if you have:
-- 720p video upscaling to 1080p: external shader upscales to 1440p, then downscaled to 1080p by `dscale=mitchell`.
-- 720p video upscaling to 2160p/4K: external shader upscales to 1440p, then upscaled to 2160p by `scale=spline36`.
+Below is a brief list of recommended external shaders for [mpv](https://mpv.io):
 
-Some shaders can upscale to arbitrary ratios, such as [ravu-zoom](https://github.com/bjin/mpv-prescalers). *This comes at the cost of lower performance, due to the shader rendering directly to the target resolution.*
++++ High-End PCs
+For those with high-end hardware, we recommend using [nnedi3-nns256-win8x4](https://github.com/bjin/mpv-prescalers/blob/master/nnedi3-nns256-win8x4.hook).
+
++++ Mid-End PCs
+For those with mid-end hardware, we recommend using [nnedi3-nns128-win8x4](https://github.com/bjin/mpv-prescalers/blob/master/nnedi3-nns128-win8x4.hook).
+
++++ Low-End PCs
+For those with low-end hardware, we recommend sticking to mpv's default shaders:
+- `scale=ewa_lanczos`
+- `dscale=mitchell`
+- `cscale=ewa_lanczos`
+
++++
 
 ==- Installing External Shaders in mpv
 - Head to your shader folder (`%appdata%/mpv/shaders`). *You may need to create one if it doesn't exist.*
@@ -110,7 +127,7 @@ Some shaders can upscale to arbitrary ratios, such as [ravu-zoom](https://github
 glsl-shader="~~/shaders/<name>"
 ```
 - Confirm your shader is working by pressing *Shift* + *I*, followed by *2*.
-   - Watch for dropped frames or high frame times, as they are a signal that your GPU may not be able to keep up with your shader. *If this applies to you, we suggest switching to a less-demanding shader.*
+   - Watch for dropped frames or high frame times, as they can be a sign that your GPU is unable to keep up with your shader. *If this applies to you, we suggest switching to a less-demanding shader.*
 
 ===
 
@@ -154,19 +171,19 @@ This process is repeated for the entire video. Because each frame is shown for a
 
 To avoid judder, *it is best to try and match your display's refresh rate with the content frame rate:*
 
-==- High Refresh Rate
+==- Using a High Refresh Rate
 Displays that run at 120Hz, 144Hz, 240Hz, or 360Hz will match perfectly with each frame, as they are all multiples of 24.
 
 *144Hz displays will not display 30/60 fps content properly. Additionally, none of the above will handle 25 fps content correctly.*
 
-==- Adaptive Sync
+==- Using Adaptive Sync
 Adaptive sync is a technology that dynamically adjusts your display's refresh rate based on the frame rate of the content on your screen.
 
 Most modern GPUs will have adaptive sync functionality, such as through AMD FreeSync or NVIDIA G-Sync.
 
 The best solution is to use G-Sync/G-Sync Compatible or FreeSync Premium. *Normal FreeSync may work if your monitor supports [Low Framerate Compensation (LFC)](https://www.amd.com/en/technologies/free-sync-faq#faq-What-is-Low-Framerate-Compensation?). You will also need to use a media player that supports adaptive sync, such as [mpv](https://mpv.io).*
 
-==- Automatic Refresh Rate Adjustment
+==- Using Automatic Refresh Rate Adjustment
 Many modern streaming devices (e.g. Apple TV, NVIDIA Shield, Amazon Fire Stick, etc.) will have the option to change the TV refresh rate to match the content frame rate, either through the device's settings or a setting in the playback software (e.g. Kodi, Plex, etc.)
 
 24/30/60 fps content should all work perfectly. *25 fps content requires 25/50Hz support, which some TVs in [NTSC regions](https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/PAL-NTSC-SECAM.svg/2560px-PAL-NTSC-SECAM.svg.png) do not support.*
@@ -196,10 +213,10 @@ Most TVs and boxes will display a list of supported codecs in their specificatio
 
 ### Typesetting
 
-Most subbed anime will use `.ass` subtitle styling, also known as Aegisub subtitles.
+Most subbed anime will use `.ass` subtitles, allowing for extensive styling and typesetting. *This comes at the cost of additional system resources, though most modern computers, phones, and media servers will not have an issue.*
 
 While subtitles will show up on most TVs/media players, the typesetting or overlapping dialogue can sometimes be broken when using certain applications. *This is especially a problem with fansubs, where typesetting is used extensively in various areas (e.g. text on a sign, moving scenes).*
 
 !!!
-[Kodi](https://kodi.tv) does not have this issue and renders `.ass` subtitles properly. *Additionally, the Kodi player is separate from the Kodi media server and is compatible with other media servers, such as [Plex](https://www.plex.tv).*
+Some TVs will have difficulty showing `.ass` subtitles. *We suggest you use an external box, such as Apple TV, Fire TV, or NVIDIA Shield.*
 !!!

--- a/docs/guides/playback.md
+++ b/docs/guides/playback.md
@@ -49,7 +49,7 @@ In a typical setup, the server is installed on a computer hosted on your home ne
 - [Jellyfin](https://jellyfin.org)
 
 !!!
-Running a media server requires a rigid folder structure and a set file naming scheme.
+Running a media server requires a rigid folder structure and a specific file naming scheme.
 
 *See the guides for your server: [Jellyfin](https://jellyfin.org/docs/general/server/media/shows), [Plex](https://support.plex.tv/articles/naming-and-organizing-your-movie-media-files/)*
 !!!
@@ -95,11 +95,11 @@ Scaling is the process of taking content that does not match your screen resolut
 
 For displays that match the content resolution, scaling isn't necessary. *These shaders only activate when these resolutions don't match. Scaling is not an enhancement and cannot be enabled manually.*
 
-[mpv](https://mpv.io) has a built-in high-quality profile called `gpu-hq` which enables better upscaling algorithms (`scale=spline36`, `cscale=spline36`, `dscale=mitchell`). By default, mpv uses `spline36`. *This option is necessary to enable even if you use external shaders, as it can act as a fallback.*
+[mpv](https://mpv.io) has a built-in high-quality profile called `gpu-hq` which enables better upscaling algorithms (`scale=spline36`, `cscale=spline36`, `dscale=mitchell`). By default, mpv uses `spline36`. *This option is necessary to enable even if you use an external shader, as it can act as a fallback.*
 
-#### External Shaders
+#### Recommended Shaders
 
-Below is a brief list of recommended external shaders for [mpv](https://mpv.io):
+Below is a brief list of recommended shaders for [mpv](https://mpv.io):
 
 +++ High-End PCs
 For those with high-end hardware, we recommend using [nnedi3-nns256-win8x4](https://github.com/bjin/mpv-prescalers/blob/master/nnedi3-nns256-win8x4.hook).
@@ -124,7 +124,7 @@ cscale=ewa_lanczos
 - Head to your shader folder (`%appdata%/mpv/shaders`). *You may need to create one if it doesn't exist.*
 - Place your downloaded external shaders in the directory.
 - Add the following line to your `mpv.conf`, replacing `<name>` with the file name of your shader:
-```
+```properties
 glsl-shader="~~/shaders/<name>"
 ```
 - Confirm your shader is working by pressing *Shift* + *I*, followed by *2*.
@@ -151,12 +151,12 @@ Most modern anime will play close to 24 fps (24000/1001 = 23.976 fps). *However,
 Judder is most commonly seen with devices that have 60Hz displays, *as the refresh rate is not an integer multiple of the content frame rate.*
 
 ==- Explaining Judder
-A 60Hz monitor can refresh up to 60 frames every second. Thus, if you were to play a video/game locked at:
+A 60Hz monitor can refresh up to 60 frames every second. Thus, if you were to play a video or game locked at:
 - 60 fps: 1 frame is shown for *every 1 refresh* (next frame in 16.67 ms).
 - 30 fps: 1 frame is shown for *every 2 refreshes* (next frame in 33.33 ms).
 - 15 fps: 1 frame is shown for *every 4 refreshes* (next frame in 66.67 ms).
 
-These frame rates work because they divide evenly into the monitor's 60Hz refresh rate. *With 60 fps video, for instance, each frame is shown for 1 refresh on a 60Hz monitor, with the next frame always appearing 16.67 ms later than the first.*
+These frame rates work because they divide evenly into the monitor's 60Hz refresh rate. *With 60 fps video, for instance, each frame is shown per refresh on a 60Hz monitor, with the next frame always appearing 16.67 ms later than the first.*
 
 If anime plays at 24 fps, your monitor will need to show 1 frame for every 2.5 refreshes (60Hz divided by 24 fps). *However, refreshes cannot be divided, and you cannot have "part" of a refresh show on your monitor.*
 
@@ -166,7 +166,9 @@ Instead, your monitor will try to refresh 2.5 times like this:
 - Frame 3 is shown for *2 refreshes* (next frame in 33.33 ms).
 - Frame 4 is shown for *3 refreshes* (next frame in 50 ms).
 
-This process is repeated for the entire video. Because each frame is shown for a different number of refreshes, plus the time between changing frames is not the same, *it leads to motion appearing stuttery/laggy. This is especially noticeable when panning scenes.* 
+Every odd frame appears for *2 refreshes*, and every even frame appears for *3 refreshes*. 
+
+This process is repeated for the entire video. Because each frame is displayed for a different number of refreshes, plus the time between changing frames is not the same, *it leads to motion appearing stuttery or laggy. This is especially noticeable when panning scenes.*
 
 ===
 
@@ -178,14 +180,14 @@ Displays that run at 120Hz, 144Hz, 240Hz, or 360Hz will match perfectly with eac
 *144Hz displays will not display 30/60 fps content properly. Additionally, none of the above will handle 25 fps content correctly.*
 
 ==- Using Adaptive Sync
-Adaptive sync is a technology that dynamically adjusts your display's refresh rate based on the frame rate of the content on your screen.
+Adaptive sync, also known as variable refresh rate, is a technology that dynamically adjusts your display's refresh rate based on the frame rate of the content on your screen.
 
-Most modern GPUs will have adaptive sync functionality, such as through AMD FreeSync or NVIDIA G-Sync.
+Most modern GPUs will have adaptive sync functionality, such as through AMD FreeSync or NVIDIA G-SYNC.
 
-The best solution is to use G-Sync/G-Sync Compatible or FreeSync Premium. *Normal FreeSync may work if your monitor supports [Low Framerate Compensation (LFC)](https://www.amd.com/en/technologies/free-sync-faq#faq-What-is-Low-Framerate-Compensation?). You will also need to use a media player that supports adaptive sync, such as [mpv](https://mpv.io).*
+The best solution is to use G-SYNC/G-SYNC Compatible or FreeSync Premium. *Normal FreeSync may work if your monitor supports [Low Framerate Compensation (LFC)](https://www.amd.com/en/technologies/free-sync-faq#faq-What-is-Low-Framerate-Compensation?). You will also need to use a media player that supports adaptive sync, such as [mpv](https://mpv.io).*
 
 ==- Using Automatic Refresh Rate Adjustment
-Many modern streaming devices (e.g. Apple TV, NVIDIA Shield, Amazon Fire Stick, etc.) will have the option to change the TV refresh rate to match the content frame rate, either through the device's settings or a setting in the playback software (e.g. Kodi, Plex, etc.)
+Many modern streaming devices (e.g. Amazon Fire TV, Apple TV, NVIDIA SHIELD, etc.) will have the option to change the TV refresh rate to match the content frame rate, either through the device's settings or a setting in the playback software (e.g. Kodi, Plex, etc.)
 
 24/30/60 fps content should all work perfectly. *25 fps content requires 25/50Hz support, which some TVs in [NTSC regions](https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/PAL-NTSC-SECAM.svg/2560px-PAL-NTSC-SECAM.svg.png) do not support.*
 
@@ -203,7 +205,7 @@ There are two ways to handle video decoding: hardware and software. *Hardware de
 
 For most users, this isn't an issue. Generally:
 - H.264 8-bit (AVC) works everywhere.
-- H.264 10-bit (AVC) works on some hardware. *Recommended to use a decent CPU. Additionally, hardware decoding support is suboptimal.*
+- H.264 10-bit (AVC) works on some hardware. *Recommended to use a decent CPU. Hardware decoding support is suboptimal.*
 - H.265 8-bit/10-bit (HEVC) works with most modern hardware.
 
 Most TVs and boxes will display a list of supported codecs in their specifications.
@@ -219,5 +221,5 @@ Most subbed anime will use `.ass` subtitles, allowing for extensive styling and 
 While subtitles will show up on most TVs/media players, the typesetting or overlapping dialogue can sometimes be broken when using certain applications. *This is especially a problem with fansubs, where typesetting is used extensively in various areas (e.g. text on a sign, moving scenes).*
 
 !!!
-Most TVs will have difficulty showing `.ass` subtitles. *You should use an external box, such as Apple TV, Fire TV, or NVIDIA Shield.*
+Most TVs will have difficulty showing `.ass` subtitles. *You should use an external box, such as Amazon Fire TV, Apple TV, or NVIDIA SHIELD.*
 !!!

--- a/docs/guides/playback.md
+++ b/docs/guides/playback.md
@@ -5,115 +5,201 @@ order: -2
 
 # Playback
 
-## Video players
+## Media Players
 
-#### PC
+==- PC
+- [MPC-HC](https://github.com/clsid2/mpc-hc/releases) - [Configuration guide with madVR](https://kokomins.wordpress.com/2021/03/27/mpc-hc-and-madvr-setup-guide/)
+- [mpv](https://mpv.io/installation/) - [Installation and configuration tutorial](/tutorials/mpv) (recommended)
+- [Potplayer](https://potplayer.daum.net)
 
-- [MPV](https://mpv.io/installation/) - [Installation and configuration tutorial](/tutorials/mpv) (recommended)
-- [MPC-HC](https://github.com/clsid2/mpc-hc/releases)/[Potplayer](https://potplayer.daum.net) - [Configuration guide with MadVR](https://kokomins.wordpress.com/2021/03/27/mpc-hc-and-madvr-setup-guide/)
+==- Android
+- [mpv-android](https://play.google.com/store/apps/details?id=is.xyz.mpv)
+- [VLC for Android](https://play.google.com/store/apps/details?id=org.videolan.vlc)
 
-VLC is not recommended because it often displays wrong colours, introduces visual artifacts, and breaks intensive subtitles. Here are some comparisons showing these issues -
+==- iOS
+- [Outplayer](https://apps.apple.com/app/outplayer/id1449923287)
+- [VLC media player](https://apps.apple.com/app/vlc-media-player/id650377962)
 
-https://slow.pics/c/XhbmrYgU (Spice and Wolf by MTBB)
-https://slow.pics/c/vH560pvp
+==- TV/Media Servers
+- [Emby](https://emby.media)
+- [Jellyfin](https://jellyfin.org)
+- [Kodi](https://kodi.tv) - *Can be installed optionally through [LibreElec OS](https://libreelec.tv).*
+- [Plex](https://www.plex.tv)
 
-#### Android
+===
 
-- [mpv-android](https://play.google.com/store/apps/details?id=is.xyz.mpv&hl=lv&gl=US)
-- [MX player](https://play.google.com/store/apps/details?id=com.mxtech.videoplayer.ad&hl=lv&gl=US)
+!!!warning
+VLC is not recommended as it introduces visual artifacts, displays wrong colors, and breaks intensive subtitles. *We suggest using alternative media players.*
 
-#### iOS
+*See the example comparisons below:*
+- https://slow.pics/c/XhbmrYgU
+- https://slow.pics/c/vH560pvp
 
-- [MX player](https://apps.apple.com/in/app/mx-player/id1429703801)
-- [Outplayer](https://apps.apple.com/us/app/outplayer/id1449923287)
+!!!
 
-#### TV
+## Media Servers
 
-- [Kodi](https://kodi.tv), optionally through [LibreElec(Minimal OS)](https://libreelec.tv)
+The setup consists of two parts: the **server** and the **client**. *Both may be installed on the same system, but they're separate applications.*
+- The **client** is a media player that will access the content stored on the server.
+- The **server** runs on the device which hosts your content.
 
-There are three ways of using Kodi on a TV -
+In a typical setup, the server is installed on a computer hosted on your home network, with the client being installed on all your devices. *Most media players will also come with their own client, as well as including support for using [Kodi](https://kodi.tv) as a client (recommended for anime).*
 
-**1. Kodi installed on a computer which stores the content and is directly connected to the TV.**
+- [Emby](https://emby.media)
+- [Plex](https://www.plex.tv) - [Guide for Anime](https://docs.google.com/document/d/1sXKZDYzbBDDWS8eqJ3IcaxSWhYKIPDdtChm74CBJ6ig)
+- [Jellyfin](https://jellyfin.org)
 
-- No decoding problems with a powerful cpu.
-- Possibility to use high quality shaders that utilize your gpu to improve upscaling with [an external player of your choice.](https://kodi.wiki/view/External_players)
-- Control using a normal mouse+keyboard or through an android app like [Yatse.](https://yatse.tv/)
+==- Scanning Anime Without Renaming
+- [Scanning files without renaming them](https://kodi.wiki/view/Anime#Scanning_files_without_renaming_them) [!badge Kodi]
+- [Absolute Series Scanner](https://github.com/ZeroQI/Hama.bundle) [!badge Plex]
 
-**2. Kodi on a TV/Android box with the content on a separate computer.**
+===
 
+### Kodi
+
+There are three ways of installing and configuring Kodi for your TV:
+
+==- Client on PC: Content stored on the computer
+- No decoding problems with a powerful CPU.
+- The ability to use high-quality shaders that utilize your GPU to improve upscaling with [an external player of your choice](https://kodi.wiki/view/External_players).
+- Control using a normal keyboard and mouse or through an Android app like [Yatse](https://yatse.tv).
+
+==- Client on TV/Android box: Content stored on a separate computer
 - Works with a simple [SMB share](https://kodi.wiki/view/SMB) from your computer on the same network.
 
-**3. Kodi on a TV/Android box with the content on a separate computer running a media server.**
+==- Client on TV/Android box: Content stored on a separate computer running a media server
+- Transcoding support for videos.
+- The ability to remotely stream content from devices outside your local network.
 
-- Transcoding support
-- Remote streaming support outside your local network
+Transcoding is used as a last resort to deal with compatibility problems. *Direct play is always preferable to transcoding, which affects quality and uses CPU power on your server. See [Plex's article about transcoding](https://support.plex.tv/articles/200250387-streaming-media-direct-play-and-direct-stream).*
 
-Transcoding is only a last resort to deal with compatibility problems. Direct play is always prefereble to transcoding, which affects quality and uses cpu power on your server. More about transcoding on plex - https://support.plex.tv/articles/200250387-streaming-media-direct-play-and-direct-stream/
-
-Here, Kodi acts as a client,increasing compatibility and replacing the default one that comes with Plex, Emby or Jellyfin. This is done through their respective add-ons for kodi.
-
-- [PlexKodiConnect](https://github.com/croneter/PlexKodiConnect)
+Here, Kodi acts as the client, increasing compatibility and replacing the default one that comes with Emby, Plex, or Jellyfin. This is done through their respective add-ons:
 - [Emby for Kodi](https://github.com/MediaBrowser/plugin.video.emby)
+- [PlexKodiConnect](https://github.com/croneter/PlexKodiConnect)
 - [Jellyfin for Kodi](https://github.com/jellyfin/jellyfin-kodi)
 
-## Media Server
+===
 
-The setup consists of two parts - the server and the client. A client is simply a media player that will access the content from a server. The server runs on the device which stores your content. Both may be installed on the same system, but they're separate applications. Usually you'd have the server on a computer connected to other devices in your home network and a client installed on all of those devices. All three of the popular ones come with their own client/player as well as support for using kodi as a client (recommended for anime).
+## Settings
 
-- [Plex](https://www.plex.tv/) - [Guide for Anime](https://docs.google.com/document/d/1sXKZDYzbBDDWS8eqJ3IcaxSWhYKIPDdtChm74CBJ6ig)
-- [Emby](https://emby.media/)
-- [Jellyfin](https://jellyfin.org/)
+### Scaling
 
-### Scanning anime without renaming
+Scaling is the process of taking content that does not match your screen resolution and scaling it to fit your display.
+- Downscaling takes a *large* video and scales *downwards* (e.g. 1080p video to 720p display)
+- Upscaling takes a *small* video and scales *upwards* (e.g. 1080p video to 2160p/4K display)
 
-- https://kodi.wiki/view/Anime#Scanning_files_without_renaming_them
-- [Absolute Series Scanner for Plex](https://github.com/ZeroQI/Hama.bundle)
+For displays that match the content resolution, scaling isn't necessary. *These shaders only activate when these resolutions don't match. Scaling is not an enhancement and cannot be enabled manually.*
 
-## Scaling
+[mpv](https://mpv.io) has a built-in high-quality profile called `gpu-hq` which enables better upscaling algorithms (`scale=spline36`, `cscale=spline36`, `dscale=mitchell`). *This option is necessary to enable even if you use external shaders, as it can act as a fallback.*
 
-1. Quality is not the same as resolution.
-2. Whenever something with a different resolution than your display is playing on it in full screen mode, then something is scaling it to the resolution of the display.
+For those with powerful GPUs, we recommend using the following external shaders for mpv:
+- [RAVU and nnedi3](https://github.com/bjin/mpv-prescalers)
+- [FSRCNNX](https://github.com/igv/FSRCNN-TensorFlow/releases)
 
-This something is usually the video player. For example, playing a 1080p video on a 2160p monitor means that it has to be upscaled to fill the screen, otherwise it'd simply play in 1/4th of the screen. Upscaling is not a choice that you can enable or disable while in full screen, the only thing that can be changed is the method of scaling. Consequently, upscaling is not something you can use to "enhance" the video when playing back at the same resolution. It is not a way to somehow improve 1080p video playing on a 1080p display. The shaders activate only when the video resolution does not match the screen resolution and scaling is needed.
+These are 2x shaders, meaning they always scale by 2x, regardless of the original video. For instance, if you have:
+- 720p video upscaling to 1080p: external shader upscales to 1440p, then downscaled to 1080p by `dscale=mitchell`.
+- 720p video upscaling to 2160p/4K: external shader upscales to 1440p, then upscaled to 2160p by `scale=spline36`.
 
-The default scaling on most players is bad. Mpv has a built in high quality profile called gpu-hq which enables better upscaling algorithms (scale=spline36, cscale=spline36, dscale=mitchell). This option is necessary even if you use external shaders to act as a fallback. Any scaling options explicitly specified after this will override it. For those with powerful gpus, even higher quality external shaders are available - FSRCNNX, NNEDI etc. The file has to be placed in %appdata%/mpv/shaders and the line `glsl-shader="~~/FSRCNNX_x2_8-0-4-1.glsl"` has to be added to the config. Press shift+I followed by 2 for confirmation that the shader is working. Dropped frames or high frame times (above 25ms) are a signal that your gpu isn't able to keep up and you should switch to a less demanding shader.
+Some shaders can upscale to arbitrary ratios, such as [ravu-zoom](https://github.com/bjin/mpv-prescalers). *This comes at the cost of lower performance, due to the shader rendering directly to the target resolution.*
 
-The shaders mentioned above are 2x scalers, which means that they always scale by 2x. For 720p to 1080p, the video will first be scaled to 1440p by FSRCNNX and then downscaled to 1080p by dscale=mitchell. For 720p to 2160p, FSRCNNX will do 720p to 1440p and then scale=spline36 will scale it the rest of the way to 2160p. When scaling below a certain threshold is required, FSRCNNX will not activate and mpv will fallback to spline36. There are also scalers like ravu-zoom can upscale to arbitrary ratios, at the cost of slow performance because of rendering to the target resolution directly.
+==- Installing External Shaders in mpv
+- Head to your shader folder (`%appdata%/mpv/shaders`). *You may need to create one if it doesn't exist.*
+- Place your downloaded external shaders in the directory.
+- Add the following line to your `mpv.conf`, replacing `<name>` with the file name of your shader:
+```
+glsl-shader="~~/shaders/<name>"
+```
+- Confirm your shader is working by pressing *Shift* + *I*, followed by *2*.
+   - Watch for dropped frames or high frame times, as they are a signal that your GPU may not be able to keep up with your shader. *If this applies to you, we suggest switching to a less-demanding shader.*
 
-Ravu and NNEDI - https://github.com/bjin/mpv-prescalers
-FSRCNNX - https://github.com/igv/FSRCNN-TensorFlow/releases
+===
 
-## Filtering
+### Filtering
 
-The same kind of filtering that is used by encoders but in real time. It's not an alternative to a good encode, but rather a temporary fix for web sources. Debanding is the most commonly used and the only one necessary. Detail enhancement, noise reduction, sharpening etc. are not recommended. All these options are available with both mpv and madvr. More about quality, video artifacts and encoding in the [quality guide](/guides/quality).
+Filters act as a temporary fix to amend issues that may appear when watching anime. These can be applied using the options available in [mpv](https://mpv.io) and [madVR](https://madvr.com).
 
-## Smooth Playback
+Debanding is the most commonly used filter, which helps to fix issues with [color banding](https://en.wikipedia.org/wiki/Colour_banding) in your video.
 
-**The problem:** Almost all anime plays back at 23.976fps (technically 24000/1001) but we'll round up to 24fps for convenience. However, displays often run at refresh rates that do not match this frame rate, leading to an effect known as judder.
-Judder is most commonly seen with laptops/desktops that have 60hz displays, because the refresh rate is not an integer multiple of the content frame rate. 60hz/24fps is 2.5, and since you can't refresh 2.5 times per frame, it has to be averaged out over time. In this case the first frame will be held for 2 refreshes, the second frame for 3 refreshes, the third for 2 and so on leading to the 2.5 average. Because of this, each frame is shown for a different amount of time (33.3ms for even frames, 50ms for odd) which leads to motion appearing stuttery/laggy, this is especially noticeable during panning scenes.
-While almost all anime is 24fps, you also may watch other content such as live action (sometimes 25fps) and YouTube (mostly 30/60fps, sometimes 25/50fps) and if you do, it's important to be able to play those frame rates back properly.
+!!!warning
+We do not recommend using detail enhancement, noise reduction, or sharpening filters with your media player, *as it can negatively affect the quality of your content.*
+!!!
 
-**The solution:** Matching the display refresh rate to the content frame rate, of which there are many methods
+*See the [Quality Guide](/guides/quality) for more information.*
 
-**Adaptive sync:** G-Sync/G-Sync Compatible (Certified)/Freesync Premium is by far the best solution, however requires the correct GPU and monitor to utilise. The display will perfectly match the content regardless of the frame rate. Normal Freesync may work, however only if the monitor supports LFC.
-Be sure to use a player that will activate adaptive sync, such as MPV.
+### Smooth Playback
 
-**Automatic Refresh Rate Adjustment:** Many streaming devices (Apple TV, Shield, Fire stick etc) will have the ability to change a TVs refresh rate to match the content frame rate, either through the device settings itself or a setting in the playback software (Kodi, Plex etc). 24/30/60fps content should all work perfectly, however 25fps content requires 25/50hz support, which some TVs in [NTSC regions](https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/PAL-NTSC-SECAM.svg/2560px-PAL-NTSC-SECAM.svg.png) may not support.
+Most modern anime will play close to 24 fps (24000/1001 = 23.976 fps). *However, most displays often run at refresh rates that do not match this frame rate, leading to an effect known as **judder**.*
 
-**High refresh rate displays:** 120hz, 144hz, 240hz, and 360hz are all multiples of 24, and as such will match perfectly since each frame can be repeated for multiple refreshes. However 144hz will not display 30/60fps content properly, and none of the above will handle 25fps content correctly.
+Judder is most commonly seen with devices that have 60Hz displays, *as the refresh rate is not an integer multiple of the content frame rate.*
+
+==- Explaining Judder
+A 60Hz monitor can refresh up to 60 frames every second. Thus, if you were to play a video/game locked at:
+- 60 fps: 1 frame is shown for *every 1 refresh* (next frame in 16.67 ms).
+- 30 fps: 1 frame is shown for *every 2 refreshes* (next frame in 33.33 ms).
+- 15 fps: 1 frame is shown for *every 4 refreshes* (next frame in 66.67 ms).
+
+These frame rates work because they divide evenly into the monitor's 60Hz refresh rate. *With 60 fps video, for instance, each frame is shown for 1 refresh on a 60Hz monitor, with the next frame always appearing 16.67 ms later than the first.*
+
+If anime plays at 24 fps, your monitor will need to show 1 frame for every 2.5 refreshes (60Hz divided by 24 fps). *However, refreshes cannot be divided, and you cannot have "part" of a refresh show on your monitor.*
+
+Instead, your monitor will try to refresh 2.5 times like this:
+- Frame 1 is shown for *2 refreshes* (next frame in 33.33 ms).
+- Frame 2 is shown for *3 refreshes* (next frame in 50 ms).
+- Frame 3 is shown for *2 refreshes* (next frame in 33.33 ms).
+- Frame 4 is shown for *3 refreshes* (next frame in 50 ms).
+
+This process is repeated for the entire video. Because each frame is shown for a different number of refreshes, plus the time between changing frames is not the same, *it leads to motion appearing stuttery/laggy. This is especially noticeable when panning scenes.* 
+
+===
+
+To avoid judder, *it is best to try and match your display's refresh rate with the content frame rate:*
+
+==- High Refresh Rate
+Displays that run at 120Hz, 144Hz, 240Hz, or 360Hz will match perfectly with each frame, as they are all multiples of 24.
+
+*144Hz displays will not display 30/60 fps content properly. Additionally, none of the above will handle 25 fps content correctly.*
+
+==- Adaptive Sync
+Adaptive sync is a technology that dynamically adjusts your display's refresh rate based on the frame rate of the content on your screen.
+
+Most modern GPUs will have adaptive sync functionality, such as through AMD FreeSync or NVIDIA G-Sync.
+
+The best solution is to use G-Sync/G-Sync Compatible or FreeSync Premium. *Normal FreeSync may work if your monitor supports [Low Framerate Compensation (LFC)](https://www.amd.com/en/technologies/free-sync-faq#faq-What-is-Low-Framerate-Compensation?). You will also need to use a media player that supports adaptive sync, such as [mpv](https://mpv.io).*
+
+==- Automatic Refresh Rate Adjustment
+Many modern streaming devices (e.g. Apple TV, NVIDIA Shield, Amazon Fire Stick, etc.) will have the option to change the TV refresh rate to match the content frame rate, either through the device's settings or a setting in the playback software (e.g. Kodi, Plex, etc.)
+
+24/30/60 fps content should all work perfectly. *25 fps content requires 25/50Hz support, which some TVs in [NTSC regions](https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/PAL-NTSC-SECAM.svg/2560px-PAL-NTSC-SECAM.svg.png) do not support.*
+
+![](https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/PAL-NTSC-SECAM.svg/2560px-PAL-NTSC-SECAM.svg.png)
+
+===
 
 ## Compatibility
 
-Decoding is the process of playing the video file. There are two types - hardware and software. Everything can be decoded, the difference is in the amount of work needed to do that. When it's hardware accelerated, it doesn't put any strain on your device cpu.
+### Codecs
 
-Most PC players will decode everything with swdecode as a fallback option. The problem is when this decoding isn't fast enough to play your video in real time. That won't ever be a problem is hwdecode is supported for that codec.
+Decoding is the process of playing the video file.
 
-If you're watching on a TV/+Android box, you'll see a list of supported codecs in their specifications. Plex and other media servers will recognize a format as not supported and start transcoding to h264 8 bit. Kodi player is the better option it'll fallback to software decoding like on a PC, giving you the option to always direct stream or run without a server. However, since the cpu on your tv/box is much weaker compared to a PC, there will be instances of horrible lag when trying to force swdecode. Note that software decoding utilizes your cpu, so the cause of lag isn't limited to decoding. It's anything that might be using your cpu at the time. Like when there's a lot of complicated .ass typesetting which needs to be rendered, that will lag with a weak cpu no matter what the video codec is. Generally -
+There are two ways to handle video decoding: hardware and software. *Hardware decoding removes additional strain from your CPU as it uses your video hardware. By default, most PC players will decode everything using software as a fallback.*
 
-- h264 8-bit works everywhere
-- h264 10-bit rarely works without a decent cpu. Hardware decode support for this is non-existent.
-- h265 8-bit and 10-bit work when hardware support exists. Most newer devices in the last 5 years support it.
+For most users, this isn't an issue. Generally:
+- H.264 8-bit (AVC) works everywhere.
+- H.264 10-bit (AVC) works on some hardware. *Recommended to use a decent CPU. Additionally, hardware decoding support is suboptimal.*
+- H.265 8-bit/10-bit (HEVC) works with most modern hardware.
+
+Most TVs and boxes will display a list of supported codecs in their specifications.
+
+[Plex](https://www.plex.tv) and other media servers will recognize unsupported formats and start transcoding to a supported format, such as H.264.
+
+[Kodi](https://kodi.tv) can fallback to software decoding like on PC media players, giving you the option to directly stream from your server or run without it. *However, since the CPU on your TV/box is much weaker, there may be instances of lag when forcing software decoding. On top of the strain from decoding, any additional CPU activity may further affect your experience, such as rendering complicated `.ass` typesettings.*
 
 ### Typesetting
 
-Anime usually has .ass subtitle styling, while the subs will show up on most TVs and players (plex, emby, jellyfin etc.), the typesetting or overlapping dialogue is sometimes broken. This is especially a problem if you're watching fansubs. **Kodi** is one of the few players which supports proper ass rendering. Note that the player is separate from the kodi media server and can even be used with plex.
+Most subbed anime will use `.ass` subtitle styling, also known as Aegisub subtitles.
+
+While subtitles will show up on most TVs/media players, the typesetting or overlapping dialogue can sometimes be broken when using certain applications. *This is especially a problem with fansubs, where typesetting is used extensively in various areas (e.g. text on a sign, moving scenes).*
+
+!!!
+[Kodi](https://kodi.tv) does not have this issue and renders `.ass` subtitles properly. *Additionally, the Kodi player is separate from the Kodi media server and is compatible with other media servers, such as [Plex](https://www.plex.tv).*
+!!!

--- a/docs/guides/playback.md
+++ b/docs/guides/playback.md
@@ -9,49 +9,50 @@ image: https://user-images.githubusercontent.com/78981416/215166522-1d7358e8-bec
 
 ## Media Players
 
-==- PC
++++ PC :desktop_computer:
+
+- [mpv](https://mpv.io/installation/) (Recommended) - [Installation and configuration tutorial](/tutorials/mpv)
 - [MPC-HC](https://github.com/clsid2/mpc-hc/releases) - [Configuration guide with madVR](https://kokomins.wordpress.com/2021/03/27/mpc-hc-and-madvr-setup-guide/)
-- [mpv](https://mpv.io/installation/) - [Installation and configuration tutorial](/tutorials/mpv) (recommended)
 - [Potplayer](https://potplayer.daum.net)
 
-==- Android
-- [mpv-android](https://play.google.com/store/apps/details?id=is.xyz.mpv)
++++ Android :robot_face:
+
+- [mpv-android](https://play.google.com/store/apps/details?id=is.xyz.mpv) (Recommended)
 - [VLC for Android](https://play.google.com/store/apps/details?id=org.videolan.vlc)
 
-==- iOS
++++ iOS :green_apple:
+
 - [Outplayer](https://apps.apple.com/app/outplayer/id1449923287)
 - [VLC media player](https://apps.apple.com/app/vlc-media-player/id650377962)
 
-==- TV/Media Servers
-- [Emby](https://emby.media)
-- [Jellyfin](https://jellyfin.org)
-- [Kodi](https://kodi.tv) - *Can be installed optionally through [LibreELEC OS](https://libreelec.tv).*
-- [Plex](https://www.plex.tv)
++++ TV/Media Servers :tv:
 
-===
+- [Plex](https://www.plex.tv)
+- [Kodi](https://kodi.tv) - *Can be installed optionally through [LibreELEC OS](https://libreelec.tv).*
+- [Jellyfin](https://jellyfin.org)
+- [Emby](https://emby.media)
+
++++
 
 !!!warning
-VLC is not recommended as it introduces visual artifacts, displays wrong colors, and breaks intensive subtitles. *We suggest using alternative media players.*
-
-*See the example comparisons to [mpv](https://mpv.io): [Spice and Wolf](https://slow.pics/c/XhbmrYgU), [One Piece](https://slow.pics/c/FW2nBwKP)*
+VLC is not recommended as it introduces visual artifacts, displays wrong colors, and breaks intensive subtitles. We suggest using alternative media players.
+See the example comparisons to mpv: [Spice and Wolf](https://slow.pics/c/XhbmrYgU), [One Piece](https://slow.pics/c/FW2nBwKP)
 !!!
 
 ## Media Servers
 
 The setup consists of two parts: the **server** and the **client**. *Both may be installed on the same system, but they are separate applications.*
+
 - The **client** is a media player that will access the content stored on the server.
 - The **server** runs on the device which hosts your content.
 
-In a typical setup, the server is installed on a computer hosted on your home network, with the client being installed on all your devices. *Most media players will also come with their own client, as well as including support for using [Kodi](https://kodi.tv) as a client (recommended for anime).*
+In a typical setup, the server is installed on a computer hosted on your home network, with the client being installed on all your devices. Most media players will also come with their own client, as well as including support for using [Kodi](https://kodi.tv) as a client (recommended for anime).
 
-- [Emby](https://emby.media)
-- [Plex](https://www.plex.tv)
-- [Jellyfin](https://jellyfin.org)
+- [Emby](https://emby.media) - [Plex](https://www.plex.tv) - [Jellyfin](https://jellyfin.org)
 
 !!!
 Running a media server requires a rigid folder structure and a specific file naming scheme.
-
-*See the guides for your server: [Jellyfin](https://jellyfin.org/docs/general/server/media/shows), [Plex](https://support.plex.tv/articles/naming-and-organizing-your-movie-media-files/)*
+*See the guides for your server: [Plex](https://support.plex.tv/articles/naming-and-organizing-your-movie-media-files/), [Jellyfin](https://jellyfin.org/docs/general/server/media/shows)*
 !!!
 
 ### Kodi
@@ -60,26 +61,36 @@ Running a media server requires a rigid folder structure and a specific file nam
 
 There are three ways of installing and configuring Kodi for your TV:
 
-==- Client on PC with content stored on the computer
+**Basic:** Kodi client on your computer, with content also stored on your computer.
+
+**Intermediate:** Kodi client on a TV/Android Box, with content stored on your computer.
+
+Com**Plex:** Kodi client on a TV/Android Box, with content stored on a media server.
+
++++ Basic
+
 - No decoding problems with a powerful CPU.
 - The ability to use high-quality shaders that utilize your GPU to improve upscaling with [an external player of your choice](https://kodi.wiki/view/External_players).
 - Control using a normal keyboard and mouse or through an Android app like [Yatse](https://yatse.tv).
 
-==- Client on TV/Android box with content stored on a separate computer
++++ Advanced
+
 - Works with a simple [SMB share](https://kodi.wiki/view/SMB) from your computer on the same network.
 
-==- Client on TV/Android box with content stored on a media server
++++ Com**Plex**
+
 - Transcoding support for videos.
 - The ability to remotely stream content from devices outside your local network.
 
 Transcoding is used as a last resort to deal with compatibility problems. *Direct play is always preferable to transcoding, which affects quality and uses CPU power on your server. See [Plex's article about transcoding](https://support.plex.tv/articles/200250387-streaming-media-direct-play-and-direct-stream).*
 
 Here, Kodi acts as the client, increasing compatibility and replacing the default one that comes with Emby, Plex, or Jellyfin. This is done through their respective add-ons:
+
 - [Emby for Kodi](https://github.com/MediaBrowser/plugin.video.emby)
 - [PlexKodiConnect](https://github.com/croneter/PlexKodiConnect)
 - [Jellyfin for Kodi](https://github.com/jellyfin/jellyfin-kodi)
 
-===
++++
 
 #### Scanning Files
 
@@ -90,12 +101,17 @@ Here, Kodi acts as the client, increasing compatibility and replacing the defaul
 ### Scaling
 
 Scaling is the process of taking content that does not match your screen resolution and scaling it to fit your display.
+
 - Downscaling takes a *large* video and scales *downwards* (e.g. 1080p video to 720p display)
 - Upscaling takes a *small* video and scales *upwards* (e.g. 1080p video to 2160p/4K display)
 
-For displays that match the content resolution, scaling isn't necessary. *These shaders only activate when these resolutions don't match. Scaling is not an enhancement and cannot be enabled manually.*
+For displays that match the content resolution you will only see chroma scaling, as in most video the chroma resolution is half the video resolution. *These shaders only activate when these resolutions don't match. Scaling is not an enhancement and cannot be enabled manually.*
 
 [mpv](https://mpv.io) has a built-in high-quality profile called `gpu-hq` which enables better upscaling algorithms (`scale=spline36`, `cscale=spline36`, `dscale=mitchell`). By default, mpv uses `spline36`. *This option is necessary to enable even if you use an external shader, as it can act as a fallback.*
+
+!!!
+`gpu-hq` enables debanding by default, which is not recommend for high quality sources. It should be followed by `deband=no`.
+!!!
 
 #### Recommended Shaders
 
@@ -104,13 +120,14 @@ Below is a brief list of recommended shaders for [mpv](https://mpv.io):
 +++ High-End PCs
 For those with high-end hardware, we recommend using [nnedi3-nns256-win8x4](https://github.com/bjin/mpv-prescalers/blob/master/nnedi3-nns256-win8x4.hook).
 
-+++ Mid-End PCs
-For those with mid-end hardware, we recommend using [nnedi3-nns128-win8x4](https://github.com/bjin/mpv-prescalers/blob/master/nnedi3-nns128-win8x4.hook).
++++ Mid-Range PCs
+For those with mid-range hardware, we recommend using [nnedi3-nns128-win8x4](https://github.com/bjin/mpv-prescalers/blob/master/nnedi3-nns128-win8x4.hook).
 
 +++ Low-End PCs
 For those with low-end hardware, we recommend sticking to mpv's built-in scalers.
 
 In your `mpv.conf`, add the following:
+
 ```properties
 vo=gpu
 scale=ewa_lanczos
@@ -121,14 +138,18 @@ cscale=ewa_lanczos
 +++
 
 ==- Installing External Shaders in mpv
+
 - Head to your shader folder (`%appdata%/mpv/shaders`). *You may need to create one if it doesn't exist.*
 - Place your downloaded external shaders in the directory.
+
 - Add the following line to your `mpv.conf`, replacing `<name>` with the file name of your shader:
+
 ```properties
 glsl-shader="~~/shaders/<name>"
 ```
+
 - Confirm your shader is working by pressing *Shift* + *I*, followed by *2*.
-   - Watch for dropped frames or high frame times, as they can be a sign that your GPU is unable to keep up with your shader. *If this applies to you, we suggest switching to a less-demanding shader.*
+- Watch for dropped frames or high frame times, as they can be a sign that your GPU is unable to keep up with your shader. *If this applies to you, we suggest switching to a less-demanding shader.*
 
 ===
 
@@ -139,87 +160,98 @@ Filters act as a temporary fix to amend issues that may appear when watching ani
 Debanding is the most commonly used filter, which helps to fix issues with [color banding](/tutorials/mpv/#debanding) in your video.
 
 !!!warning
-We do not recommend using detail enhancement, noise reduction, or sharpening filters with your media player, *as it can negatively affect the quality of your content.*
+We do not recommend detail enhancement, noise reduction, or sharpening filters, as it will negatively affect the quality of your content.
 !!!
 
 *See the [Quality Guide](/guides/quality) for more information.*
 
 ### Smooth Playback
 
-Most modern anime will play close to 24 fps (24000/1001 = 23.976 fps). *However, most displays often run at refresh rates that do not match this frame rate, leading to an effect known as **judder**.*
+Most modern anime will play close to 24 fps (24000/1001 fps). However, most displays often run at refresh rates that do not match this frame rate, leading to an effect known as **judder**.
 
 Judder is most commonly seen with devices that have 60Hz displays, *as the refresh rate is not an integer multiple of the content frame rate.*
 
 ==- Explaining Judder
 A 60Hz monitor can refresh up to 60 frames every second. Thus, if you were to play a video or game locked at:
+
 - 60 fps: 1 frame is shown for *every 1 refresh* (next frame in 16.67 ms).
 - 30 fps: 1 frame is shown for *every 2 refreshes* (next frame in 33.33 ms).
 - 15 fps: 1 frame is shown for *every 4 refreshes* (next frame in 66.67 ms).
 
 These frame rates work because they divide evenly into the monitor's 60Hz refresh rate. *With 60 fps video, for instance, each frame is shown per refresh on a 60Hz monitor, with the next frame always appearing 16.67 ms later than the first.*
 
-If anime plays at 24 fps, your monitor will need to show 1 frame for every 2.5 refreshes (60Hz divided by 24 fps). *However, refreshes cannot be divided, and you cannot have "part" of a refresh show on your monitor.*
+When content plays at 24 fps, your monitor will need to show 1 frame for every 2.5 refreshes (60Hz divided by 24 fps). *However, refreshes cannot be divided, and you cannot have "part" of a refresh show on your monitor without screen tearing.*
 
 Instead, your monitor will try to refresh 2.5 times like this:
+
 - Frame 1 is shown for *2 refreshes* (next frame in 33.33 ms).
 - Frame 2 is shown for *3 refreshes* (next frame in 50 ms).
 - Frame 3 is shown for *2 refreshes* (next frame in 33.33 ms).
 - Frame 4 is shown for *3 refreshes* (next frame in 50 ms).
 
-Every odd frame appears for *2 refreshes*, and every even frame appears for *3 refreshes*. 
+Every odd frame appears for *2 refreshes*, and every even frame appears for *3 refreshes*.
 
-This process is repeated for the entire video. Because each frame is displayed for a different number of refreshes, plus the time between changing frames is not the same, *it leads to motion appearing stuttery or laggy. This is especially noticeable when panning scenes.*
+This process is repeated for the entire video. Because each frame is displayed for a different number of refreshes, plus the time between changing frames is not the same, *it leads to motion appearing stuttery or laggy. This is especially noticeable during panning scenes.*
 
 ===
 
-To avoid judder, *it is best to try and match your display's refresh rate with the content frame rate:*
+To avoid judder, it is best to try and match your display's refresh rate with the content frame rate via the following methods:
 
-==- Using a High Refresh Rate
++++ High Refresh Rate
 Displays that run at 120Hz, 144Hz, 240Hz, or 360Hz will match perfectly with each frame, as they are all multiples of 24.
+
+Technically they should be set as 119.88hz, 143.86hz, 239.76hz, or 359.64hz to match with the majority of content (24000/1001)fps, roughly 23.976fps
 
 *144Hz displays will not display 30/60 fps content properly. Additionally, none of the above will handle 25 fps content correctly.*
 
-==- Using Adaptive Sync
++++ Adaptive Sync
 Adaptive sync, also known as variable refresh rate, is a technology that dynamically adjusts your display's refresh rate based on the frame rate of the content on your screen.
 
 Most modern GPUs will have adaptive sync functionality, such as through AMD FreeSync or NVIDIA G-SYNC.
 
 The best solution is to use G-SYNC/G-SYNC Compatible or FreeSync Premium. *Normal FreeSync may work if your monitor supports [Low Framerate Compensation (LFC)](https://www.amd.com/en/technologies/free-sync-faq#faq-What-is-Low-Framerate-Compensation?). You will also need to use a media player that supports adaptive sync, such as [mpv](https://mpv.io).*
 
-==- Using Automatic Refresh Rate Adjustment
-Many modern streaming devices (e.g. Amazon Fire TV, Apple TV, NVIDIA SHIELD, etc.) will have the option to change the TV refresh rate to match the content frame rate, either through the device's settings or a setting in the playback software (e.g. Kodi, Plex, etc.)
+You may need to force exclusive fullscreen in mpv to activate adaptive sync, this can be done by adding `ontop` & `fullscreen` to your config file. You can tell adaptive sync is working when your cursor feels laggy, as this means your display has dropped refresh rate to match the content.
+
++++ Automatic Refresh Rate Adjustment
+Many modern streaming devices (e.g. Amazon Fire TV, Apple TV, NVIDIA SHIELD, etc.) will have the option to change the TV refresh rate to match the content frame rate, either through the device's settings or a setting in the playback software (Kodi, Plex, etc.)
 
 24/30/60 fps content should all work perfectly. *25 fps content requires 25/50Hz support, which some TVs in [NTSC regions](https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/PAL-NTSC-SECAM.svg/2560px-PAL-NTSC-SECAM.svg.png) do not support.*
 
-![](https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/PAL-NTSC-SECAM.svg/2560px-PAL-NTSC-SECAM.svg.png)
+![NTSC Regions](https://i.imgur.com/Xb0Frlb.png)
 
-===
++++
 
 ## Compatibility
 
 ### Codecs
 
-Decoding is the process of playing the video file.
+Decoding is the process of deciphering the encoded video into a format that your device can display.
 
-There are two ways to handle video decoding: hardware and software. *Hardware decoding removes additional strain from your CPU as it uses your video hardware. By default, most PC players will decode everything using software as a fallback.*
+There are two ways to handle video decoding: Software (SW), and Hardware (HW)
+
+**Software decoding** uses your CPU to bruteforce decode any format, and is only limited by how powerful your chip is.
+
+**Hardware decoding** is vastly more efficient as it uses dedicated decoders on your GPU, resulting in better performance, less power usage, and less strain on your CPU. However older devices will not have support for newer codecs.
 
 For most users, this isn't an issue. Generally:
+
 - H.264 8-bit (AVC) works everywhere.
-- H.264 10-bit (AVC) works on some hardware. *Recommended to use a decent CPU. Hardware decoding support is suboptimal.*
+- H.264 10-bit (Hi10P) works on some hardware. *Recommended to use a decent CPU. Hardware decoding support is suboptimal.*
 - H.265 8-bit/10-bit (HEVC) works with most modern hardware.
 
-Most TVs and boxes will display a list of supported codecs in their specifications.
+Most TVs and boxes will display a list of supported codecs on their specification page.
 
 [Plex](https://www.plex.tv) and other media servers will recognize unsupported formats and start transcoding to a supported format, such as H.264.
 
-[Kodi](https://kodi.tv) can fallback to software decoding like on PC media players, giving you the option to directly stream from your server or run without it. *However, since the CPU on your TV/box is much weaker, there may be instances of lag when forcing software decoding. On top of the strain from decoding, any additional CPU activity may further affect your experience, such as rendering complicated `.ass` typesettings.*
+[Kodi](https://kodi.tv) can fallback to software decoding like on PC media players, giving you the option to directly stream from your server or run without it. *However, since the CPU on your TV/Android box is much weaker, there may be instances of lag when forcing software decoding. On top of the strain from decoding, any additional CPU activity may further affect your experience, such as rendering complicated `.ass` typesetting.*
 
 ### Typesetting
 
-Most subbed anime will use `.ass` subtitles, allowing for extensive styling and typesetting. This comes at the cost of additional system resources, *though most modern computers, phones, and media servers will not have an issue.*
+Almost all subbed anime will use `.ass` subtitles, allowing for extensive styling and typesetting. This comes at the cost of additional system resources, though most modern computers, phones, and media servers will not have an issue.
 
-While subtitles will show up on most TVs/media players, the typesetting or overlapping dialogue can sometimes be broken when using certain applications. *This is especially a problem with fansubs, where typesetting is used extensively in various areas (e.g. text on a sign, moving scenes).*
+While subtitles will display on most TVs/media players, the typesetting or overlapping dialogue can sometimes be broken when using certain applications. *This is especially a problem with fansubs, where typesetting is used extensively in various areas (e.g. text on a sign, moving scenes).*
 
 !!!
-Most TVs will have difficulty showing `.ass` subtitles. *You should use an external box, such as Amazon Fire TV, Apple TV, or NVIDIA SHIELD.*
+Most TVs will have difficulty showing `.ass` subs. You should use an external box, such as Amazon Fire TV, Apple TV, or NVIDIA SHIELD.
 !!!

--- a/docs/guides/playback.md
+++ b/docs/guides/playback.md
@@ -11,13 +11,13 @@ image: https://user-images.githubusercontent.com/78981416/215166522-1d7358e8-bec
 
 +++ PC :desktop_computer:
 
-- [mpv](https://mpv.io/installation/) [!badge Recommended] - [Installation and configuration tutorial](/tutorials/mpv)
+- [mpv](https://mpv.io/installation/) [!badge variant="info" text="Recommended"] - [Installation and configuration tutorial](/tutorials/mpv)
 - [MPC-HC](https://github.com/clsid2/mpc-hc/releases) - [Configuration guide with madVR](https://kokomins.wordpress.com/2021/03/27/mpc-hc-and-madvr-setup-guide/)
 - [Potplayer](https://potplayer.daum.net)
 
 +++ Android :robot_face:
 
-- [mpv-android](https://play.google.com/store/apps/details?id=is.xyz.mpv) [!badge Recommended]
+- [mpv-android](https://play.google.com/store/apps/details?id=is.xyz.mpv) [!badge variant="info" text="Recommended"]
 - [VLC for Android](https://play.google.com/store/apps/details?id=org.videolan.vlc)
 
 +++ iOS :green_apple:
@@ -27,8 +27,8 @@ image: https://user-images.githubusercontent.com/78981416/215166522-1d7358e8-bec
 
 +++ TV/Media Servers :tv:
 
-- [Kodi](https://kodi.tv) [!badge Recommended] - *Can be installed optionally through [LibreELEC OS](https://libreelec.tv).*
-- [Plex](https://www.plex.tv) [!badge Recommended]
+- [Kodi](https://kodi.tv) [!badge variant="info" text="Recommended"] - *Can be installed optionally through [LibreELEC OS](https://libreelec.tv).*
+- [Plex](https://www.plex.tv) [!badge variant="info" text="Recommended"]
 - [Emby](https://emby.media)
 - [Jellyfin](https://jellyfin.org)
 
@@ -48,9 +48,9 @@ The setup consists of two parts: the **server** and the **client**. *Both may be
 
 In a typical setup, the server is installed on a computer hosted on your home network, with the client being installed on all your devices. Most media players will also come with their own client, as well as including support for using [Kodi](https://kodi.tv) as a client (recommended for anime).
 
-[!button variant="info" text="Emby" margin="0 8 0 0"](https://emby.media)
-[!button variant="info" text="Plex" margin="0 8 0 0"](https://www.plex.tv)
-[!button variant="info" text="Jellyfin"](https://jellyfin.org)
+[!button variant="secondary" text="Emby" margin="0 8 0 0"](https://emby.media)
+[!button variant="secondary" text="Plex" margin="0 8 0 0"](https://www.plex.tv)
+[!button variant="secondary" text="Jellyfin"](https://jellyfin.org)
 
 !!!
 Running a media server requires a rigid folder structure and a specific file naming scheme.

--- a/docs/guides/playback.md
+++ b/docs/guides/playback.md
@@ -60,15 +60,15 @@ Running a media server requires a rigid folder structure and a set file naming s
 
 There are three ways of installing and configuring Kodi for your TV:
 
-==- Client on PC: Content stored on the computer
+==- Client on PC with content stored on the computer
 - No decoding problems with a powerful CPU.
 - The ability to use high-quality shaders that utilize your GPU to improve upscaling with [an external player of your choice](https://kodi.wiki/view/External_players).
 - Control using a normal keyboard and mouse or through an Android app like [Yatse](https://yatse.tv).
 
-==- Client on TV/Android box: Content stored on a separate computer
+==- Client on TV/Android box with content stored on a separate computer
 - Works with a simple [SMB share](https://kodi.wiki/view/SMB) from your computer on the same network.
 
-==- Client on TV/Android box: Content stored on a separate computer running a media server
+==- Client on TV/Android box with content stored on a media server
 - Transcoding support for videos.
 - The ability to remotely stream content from devices outside your local network.
 
@@ -108,10 +108,15 @@ For those with high-end hardware, we recommend using [nnedi3-nns256-win8x4](http
 For those with mid-end hardware, we recommend using [nnedi3-nns128-win8x4](https://github.com/bjin/mpv-prescalers/blob/master/nnedi3-nns128-win8x4.hook).
 
 +++ Low-End PCs
-For those with low-end hardware, we recommend sticking to mpv's default shaders:
-- `scale=ewa_lanczos`
-- `dscale=mitchell`
-- `cscale=ewa_lanczos`
+For those with low-end hardware, we recommend sticking to mpv's built-in scalers.
+
+In your `mpv.conf`, add the following:
+```properties
+vo=gpu
+scale=ewa_lanczos
+dscale=mitchell
+cscale=ewa_lanczos
+```
 
 +++
 
@@ -131,7 +136,7 @@ glsl-shader="~~/shaders/<name>"
 
 Filters act as a temporary fix to amend issues that may appear when watching anime. These can be applied using the options available in [mpv](https://mpv.io) and [madVR](https://madvr.com).
 
-Debanding is the most commonly used filter, which helps to fix issues with [color banding](https://en.wikipedia.org/wiki/Colour_banding) in your video.
+Debanding is the most commonly used filter, which helps to fix issues with [color banding](/tutorials/mpv/#debanding) in your video.
 
 !!!warning
 We do not recommend using detail enhancement, noise reduction, or sharpening filters with your media player, *as it can negatively affect the quality of your content.*
@@ -214,5 +219,5 @@ Most subbed anime will use `.ass` subtitles, allowing for extensive styling and 
 While subtitles will show up on most TVs/media players, the typesetting or overlapping dialogue can sometimes be broken when using certain applications. *This is especially a problem with fansubs, where typesetting is used extensively in various areas (e.g. text on a sign, moving scenes).*
 
 !!!
-Some TVs will have difficulty showing `.ass` subtitles. *We suggest you use an external box, such as Apple TV, Fire TV, or NVIDIA Shield.*
+Most TVs will have difficulty showing `.ass` subtitles. *You should use an external box, such as Apple TV, Fire TV, or NVIDIA Shield.*
 !!!

--- a/docs/guides/playback.md
+++ b/docs/guides/playback.md
@@ -33,9 +33,7 @@ image: https://user-images.githubusercontent.com/78981416/215166522-1d7358e8-bec
 !!!warning
 VLC is not recommended as it introduces visual artifacts, displays wrong colors, and breaks intensive subtitles. *We suggest using alternative media players.*
 
-*See the example comparisons to [mpv](https://mpv.io) below:*
-- [Spice and Wolf](https://slow.pics/c/XhbmrYgU)
-- [One Piece](https://slow.pics/c/FW2nBwKP)
+*See the example comparisons to [mpv](https://mpv.io): [Spice and Wolf](https://slow.pics/c/XhbmrYgU), [One Piece](https://slow.pics/c/FW2nBwKP)*
 !!!
 
 ## Media Servers
@@ -53,9 +51,7 @@ In a typical setup, the server is installed on a computer hosted on your home ne
 !!!
 Running a media server requires a rigid folder structure and a set file naming scheme.
 
-*See the guides below for your server:*
-- [Jellyfin](https://jellyfin.org/docs/general/server/media/shows)
-- [Plex](https://support.plex.tv/articles/naming-and-organizing-your-movie-media-files/)
+*See the guides for your server: [Jellyfin](https://jellyfin.org/docs/general/server/media/shows), [Plex](https://support.plex.tv/articles/naming-and-organizing-your-movie-media-files/)*
 !!!
 
 ### Kodi
@@ -213,7 +209,7 @@ Most TVs and boxes will display a list of supported codecs in their specificatio
 
 ### Typesetting
 
-Most subbed anime will use `.ass` subtitles, allowing for extensive styling and typesetting. *This comes at the cost of additional system resources, though most modern computers, phones, and media servers will not have an issue.*
+Most subbed anime will use `.ass` subtitles, allowing for extensive styling and typesetting. This comes at the cost of additional system resources, *though most modern computers, phones, and media servers will not have an issue.*
 
 While subtitles will show up on most TVs/media players, the typesetting or overlapping dialogue can sometimes be broken when using certain applications. *This is especially a problem with fansubs, where typesetting is used extensively in various areas (e.g. text on a sign, moving scenes).*
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,34 +8,34 @@ description: Wiki for all things related to anime and more!
 
 ![](https://user-images.githubusercontent.com/78981416/214677895-b5497a9f-b78c-4c26-8ef3-880594c67e7a.png)
 
-Welcome to the wiki for all things related to anime and more!
-Here you can find stuff ranging from easy to digest tutorials to full blown guides.
+Welcome to the wiki for all things related to anime and more, ranging from easy to digest tutorials to full blown guides!
+
 We also have a Discord server where you can hang out, report, and request things related to this wiki.
 [![](https://discordapp.com/api/guilds/974468300304171038/widget.png?style=banner2)](https://discord.gg/snackbox)
 
 #### :rocket: Getting started
 
 - [How and where to find your favorite anime](/getting-started/anime/)
-- [How and where to find your favorite manga, light novel, etc](/getting-started/literature/)
+- [How and where to find your favorite manga and light novels](/getting-started/literature/)
 - [How and where to find your favorite hentai](/getting-started/hentai/)
 
-#### :book: Learn about various topics in details
+#### :book: Learn about various topics in detail
 
-- [Various players and what's best for your device](/guides/playback/)
-- [Sourcing your favorite content in the easiest and highest quality possible](/guides/playback/)
+- [Find the best media player for your device](/guides/playback/)
+- [Source your favorite content in the highest quality possible](/guides/playback/)
 - [Learn how to torrent from scratch](/guides/torrenting/)
 
 #### :tv: Learn about the various ways to watch your anime
 
 - [Quickly and easily stream your favorite anime](/sourcing/streaming/)
-- [Download your favorite anime in the higest quality possible](/sourcing/public-trackers/)
+- [Download your favorite anime in the best quality possible](/sourcing/public-trackers/)
 - [Direct download your favorite anime](/sourcing/ddl/)
 
 #### :scroll: Some helpful tutorials
 
-- [Install and configure MPV](/tutorials/mpv/)
-- [Download your favorite weekly shows automatically](/tutorials/rss/)
-- [Compare various versions to find the best](/tutorials/comparison/)
+- [Install and configure mpv](/tutorials/mpv/)
+- [Download your favorite weekly shows automatically using RSS](/tutorials/rss/)
+- [Compare multiple releases to find what's best for you](/tutorials/comparison/)
 
 #### :floppy_disk: Want to make your own release for others to watch and enjoy?
 
@@ -47,4 +47,4 @@ We also have a Discord server where you can hang out, report, and request things
 
 #### :sparkling_heart: Want to contribute and help improve this wiki?
 
-- [Read how to contribute](/contributing)
+- [See how you can contribute](/contributing)

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ We also have a Discord server where you can hang out, report, and request things
 #### :book: Learn about various topics in detail
 
 - [Find the best media player for your device](/guides/playback/)
-- [Source your favorite content in the highest quality possible](/guides/playback/)
+- [Source your favorite content in the highest quality possible](/guides/quality/)
 - [Learn how to torrent from scratch](/guides/torrenting/)
 
 #### :tv: Learn about the various ways to watch your anime

--- a/docs/tutorials/mpv.md
+++ b/docs/tutorials/mpv.md
@@ -4,8 +4,6 @@ description: Installation, setup, and configuration for MPV
 image: https://user-images.githubusercontent.com/78981416/215125796-08b99128-fe50-4d0c-b0dd-49f8828af0dc.png
 ---
 
-# TEEST
-
 # MPV
 
 [MPV](https://mpv.io/) is a versatile and lightweight media player with extensive customization options. It supports a wide variety of video file formats, audio and video codecs, subtitle types, offers advanced features, and is compatible with multiple platforms.

--- a/docs/tutorials/mpv.md
+++ b/docs/tutorials/mpv.md
@@ -4,6 +4,8 @@ description: Installation, setup, and configuration for MPV
 image: https://user-images.githubusercontent.com/78981416/215125796-08b99128-fe50-4d0c-b0dd-49f8828af0dc.png
 ---
 
+# TEEST
+
 # MPV
 
 [MPV](https://mpv.io/) is a versatile and lightweight media player with extensive customization options. It supports a wide variety of video file formats, audio and video codecs, subtitle types, offers advanced features, and is compatible with multiple platforms.


### PR DESCRIPTION
Redesign for guides/playback.md to simplify information and utilize Retype's components for a more organized look. Similar to the changes introduced in PR https://github.com/Snaacky/thewiki/pull/78.

Some changes include:
- Fixing grammatical errors and linking in index.md.
- Removing outdated information (i.e. most media servers can't play `.ass` subs)
- Improved scaling shader recommendations for mpv.
- Condensing/revising documentation (i.e. scaling, explaining judder, codecs).

[These changes can be previewed live here.](https://ricky8k.github.io/thewiki/)