### PR TITLE
fix: rebrand streaming site 9anime to AniWave

### DIFF
--- a/docs/guides/quality.md
+++ b/docs/guides/quality.md
@@ -119,9 +119,9 @@ The process of re-encoding is generally considered a bad practice due to quality
 
 On [Nyaa](https://nyaa.si), these are marked in red. You can see the difference with re-encodes from the comparisons below:
 
-- [Dokyuu Hentai HxEros](https://slow.pics/c/PZRxqAsh) - Raw (Reinforce) vs. Encode (HorribleSubs/Crunchyroll) vs. Re-encode (9anime, animepahe, Gogoanime, Minis)
-- [Oshi no Ko](https://slow.pics/c/6HqApHsn) - Encode (Setsugen, SubsPlease/Crunchyroll) vs. Re-encode (9anime, AniWatch (Zoro), Gogoanime, Marin)
-- [Senran Kagura](https://slow.pics/c/QLtX61qx) - Raw (BDMV, Snow-Raws) vs. Re-encode (9anime, animepahe, AniWatch (Zoro), Gogoanime)
+- [Dokyuu Hentai HxEros](https://slow.pics/c/PZRxqAsh) - Raw (Reinforce) vs. Encode (HorribleSubs/Crunchyroll) vs. Re-encode (animepahe, AniWave (9anime), Gogoanime, Minis)
+- [Oshi no Ko](https://slow.pics/c/6HqApHsn) - Encode (Setsugen, SubsPlease/Crunchyroll) vs. Re-encode (AniWatch (Zoro), AniWave (9anime), Gogoanime, Marin)
+- [Senran Kagura](https://slow.pics/c/QLtX61qx) - Raw (BDMV, Snow-Raws) vs. Re-encode (animepahe, AniWatch (Zoro), AniWave (9anime), Gogoanime)
 - [Vinland Saga S2](https://slow.pics/c/GjhwBwo3) - Encode (Foxtrot, SubsPlease/Crunchyroll) vs. Re-encode (Gogoanime, Marin, Minis)
 
 +++ Mini Encode

--- a/docs/sourcing/streaming.md
+++ b/docs/sourcing/streaming.md
@@ -11,9 +11,9 @@ Majority of unofficial streaming sites will contain unwanted or annoying pop-ups
 
 ## Popular Sites
 
-- [9anime](https://9anime.to) - Self-hosted site with one of the largest and oldest anime libraries. *Releases are often updated to include fansubs and BD releases for older content.*
-- [AniWatch](https://aniwatch.to) (previously *Zoro*) - Self-hosted site with quality similar to 9anime while maintaining an extensive library. *One of the only streaming sites with soft subtitles.*
+- [AniWatch](https://aniwatch.to) (previously *Zoro*) - Self-hosted site with quality similar to AniWave while maintaining an extensive library. *One of the only streaming sites with soft subtitles.*
   - *Not to be confused with defunct streaming site [Aniwatch.me](https://aniwatch.me).*
+- [AniWave](https://aniwave.to) (previously *9anime*) - Self-hosted site with one of the largest and oldest anime libraries. *Releases are often updated to include fansubs and BD releases for older content.*
 - [Gogoanime](https://gogoanime.lu) - Self-hosted site with a vast library. *Majority of scraper sites will source from here.*
 
 See [The Index](https://theindex.moe) for a more comprehensive list of unofficial anime streaming sites.
@@ -38,7 +38,7 @@ A **self-hosted** site is a streaming site that hosts the content on their own s
 
 Typically, self-hosted sites allow for significantly better video quality compared to scrapers or other sites. They also generally pick good BD releases or fansubs for some shows. *However, some self-hosted libraries can be more limited.*
 
-**Examples of self-hosted sites:** [9anime](https://9anime.to), [animepahe](https://animepahe.com), [AniWatch](https://aniwatch.to), [Gogoanime](https://gogoanime.lu), [Marin](https://marin.moe)
+**Examples of self-hosted sites:** [animepahe](https://animepahe.com), [AniWatch](https://aniwatch.to), [AniWave](https://aniwave.to), [Gogoanime](https://gogoanime.lu), [Marin](https://marin.moe)
 
 +++ Scrapers
 
@@ -58,12 +58,12 @@ While streaming sites will offer worse video quality compared to alternatives su
 
 You can see for yourself in the quality comparisons linked below:
 
-- [Demon Slayer](https://slow.pics/c/pjYaqdnr) - 9anime, AniWatch (Zoro), animepahe, Gogoanime, Marin (Tenshi), torrents
-- [Fate/Zero](https://slow.pics/c/1LNZtDzm) - 9anime, animepahe, Gogoanime, Marin (tenshi), torrents
-- [Senran Kagura](https://slow.pics/c/QLtX61qx) - 9anime, AniWatch (Zoro), animepahe, Gogoanime, torrents
-- [Dokyuu Hentai HxEros](https://slow.pics/c/PZRxqAsh) - 9anime, animepahe, Gogoanime, torrents
+- [Demon Slayer](https://slow.pics/c/pjYaqdnr) - AniWatch (Zoro), AniWave (9anime), animepahe, Gogoanime, Marin (tenshi), torrents
+- [Fate/Zero](https://slow.pics/c/1LNZtDzm) - animepahe, AniWave (9anime), Gogoanime, Marin (tenshi), torrents
+- [Senran Kagura](https://slow.pics/c/QLtX61qx) - AniWatch (Zoro), AniWave (9anime), animepahe, Gogoanime, torrents
+- [Dokyuu Hentai HxEros](https://slow.pics/c/PZRxqAsh) - animepahe, AniWave (9anime), Gogoanime, torrents
 - [Vinland Saga S2](https://slow.pics/c/GjhwBwo3) - Gogoanime, Marin, torrents
-- [Oshi no Ko](https://slow.pics/c/6HqApHsn) - 9anime, AniWatch (Zoro), Gogoanime, Marin, torrents
+- [Oshi no Ko](https://slow.pics/c/6HqApHsn) - AniWatch (Zoro), AniWave (9anime), Gogoanime, Marin, torrents
 
 #### Quality Tier List
 
@@ -74,9 +74,9 @@ You can see for yourself in the quality comparisons linked below:
 
 +++ Tier 2 (Good)
 
-- [9anime](https://9anime.to)
 - [AniWatch](https://aniwatch.to) - *Formerly Zoro.*
   - *Not to be confused with defunct streaming site [Aniwatch.me](https://aniwatch.me).*
+- [AniWave](https://aniwave.to) - *Formerly 9anime.*
 
 +++ Tier 3 (Okay)
 
@@ -92,17 +92,17 @@ There are a multitude of other factors that may affect your decision in picking 
 ==- Fansubs and BD Releases
 [Marin](https://marin.moe) and [animepahe](https://animepahe.com) are very consistent at picking good BD releases with fansubs.
 
-[9anime](https://9anime.to) does this too, *but typically less often and with slightly worse release choice.*
+[AniWave](https://aniwave.to) does this too, *but typically less often and with slightly worse release choice.*
 
 ==- File Size
 [animepahe](https://animepahe.com) has some of the smallest file sizes compared to other streaming sites.
 
-[9anime's](https://9anime.to) are also relatively small when compared to sites like [Gogoanime](https://gogoanime.lu) and [Marin](https://marin.moe).
+[AniWave's](https://aniwave.to) are also relatively small when compared to sites like [Gogoanime](https://gogoanime.lu) and [Marin](https://marin.moe).
 
 ==- Library
-[9anime](https://9anime.to) and [Gogoanime](https://gogoanime.lu) have some of the largest libraries available.
+[AniWave](https://aniwave.to) and [Gogoanime](https://gogoanime.lu) have some of the largest libraries available.
 
-Additionally, [9anime](https://9anime.to) has one of the best libraries when it comes to older and rarer shows.
+Additionally, [AniWave](https://aniwave.to) has one of the best libraries when it comes to older and rarer shows.
 
 ==- Soft Subs
 [AniWatch](https://aniwatch.to) is one of the only streaming sites that use soft subtitles, with the other alternatives being legal streaming sites.


### PR DESCRIPTION
Streaming site [9anime](https://9anime.to) recently rebranded to [AniWave](https://aniwave.to). This PR removes their old domain and replaces it with the new destination. Added a note mentioning their former site, similar to AniWatch (https://github.com/Snaacky/thewiki/pull/81) and Marin.