### PR TITLE
feat: add new quality comparison

### DIFF
--- a/docs/guides/quality.md
+++ b/docs/guides/quality.md
@@ -119,10 +119,11 @@ The process of re-encoding is generally considered a bad practice due to quality
 
 On [Nyaa](https://nyaa.si), these are marked in red. You can see the difference with re-encodes from the comparisons below:
 
-- [Dokyuu Hentai HxEros](https://slow.pics/c/PZRxqAsh) - Raw (Reinforce) vs. Encode (HorribleSubs/Crunchyroll) vs. Re-encode (animepahe, AniWave (9anime), Gogoanime, Minis)
-- [Oshi no Ko](https://slow.pics/c/6HqApHsn) - Encode (Setsugen, SubsPlease/Crunchyroll) vs. Re-encode (AniWatch (Zoro), AniWave (9anime), Gogoanime, Marin)
+- [Dokyuu Hentai HxEros](https://slow.pics/c/PZRxqAsh) - Raw (Reinforce) vs. Official (HorribleSubs/Crunchyroll) vs. Re-encode (animepahe, AniWave (9anime), Gogoanime, Minis)
+- [Masamune-kun no Revenge R](https://slow.pics/c/rj3QjRMA) - Encode (smol) vs. Official (SubsPlease/Crunchyroll) vs. Re-encode (animepahe, AniWatch, AniWave, Gogoanime, Marin, Minis)
+- [Oshi no Ko](https://slow.pics/c/6HqApHsn) - Encode (Setsugen) vs. Official (SubsPlease/Crunchyroll) vs. Re-encode (AniWatch (Zoro), AniWave (9anime), Gogoanime, Marin)
 - [Senran Kagura](https://slow.pics/c/QLtX61qx) - Raw (BDMV, Snow-Raws) vs. Re-encode (animepahe, AniWatch (Zoro), AniWave (9anime), Gogoanime)
-- [Vinland Saga S2](https://slow.pics/c/GjhwBwo3) - Encode (Foxtrot, SubsPlease/Crunchyroll) vs. Re-encode (Gogoanime, Marin, Minis)
+- [Vinland Saga S2](https://slow.pics/c/GjhwBwo3) - Encode (Foxtrot) vs. Official (SubsPlease/Crunchyroll) vs. Re-encode (Gogoanime, Marin, Minis)
 
 +++ Mini Encode
 
@@ -130,9 +131,10 @@ Mini encodes are releases designed to save on space and bandwidth while retainin
 
 See the mini-encode comparisons below:
 
-- [Jujutsu Kaisen S2](https://slow.pics/c/HZeCzBjs) - Web (SubsPlease/Crunchyroll 1080p/720p, VARYG/Netflix) vs. Minis (A-L, Anime Time, ASW, Breeze, DKB, Judas, NanakoRaws, Sokudo, Valenciano)
+- [Masamune-kun no Revenge R](https://slow.pics/c/rj3QjRMA) - WEB (smol, SubsPlease/Crunchyroll 1080p/720p) vs. Minis (ASW, DKB, EMBER, Judas)
+- [Jujutsu Kaisen S2](https://slow.pics/c/HZeCzBjs) - WEB (SubsPlease/Crunchyroll 1080p/720p, VARYG/Netflix) vs. Minis (A-L, Anime Time, ASW, Breeze, DKB, Judas, NanakoRaws, Sokudo, Valenciano)
 - [Space Dandy](https://slow.pics/c/d5hU8mnp) - BD (MTBB) vs. Minis (AnimeRG, Cleo 1080p/720p, Commie 720p, DHD)
-- [SukiMega](https://slow.pics/c/vpcExtLb) - Web (SubsPlease/Crunchyroll 1080p/720p) vs. Minis (Anime Time, ASW, DKB, EMBER, Judas, Valenciano)
+- [SukiMega](https://slow.pics/c/vpcExtLb) - WEB (SubsPlease/Crunchyroll 1080p/720p) vs. Minis (Anime Time, ASW, DKB, EMBER, Judas, Valenciano)
 
 +++
 

--- a/docs/sourcing/streaming.md
+++ b/docs/sourcing/streaming.md
@@ -64,6 +64,7 @@ You can see for yourself in the quality comparisons linked below:
 - [Dokyuu Hentai HxEros](https://slow.pics/c/PZRxqAsh) - animepahe, AniWave (9anime), Gogoanime, torrents
 - [Vinland Saga S2](https://slow.pics/c/GjhwBwo3) - Gogoanime, Marin, torrents
 - [Oshi no Ko](https://slow.pics/c/6HqApHsn) - AniWatch (Zoro), AniWave (9anime), Gogoanime, Marin, torrents
+- [Masamune-kun no Revenge R](https://slow.pics/c/rj3QjRMA) - animepahe, AniWatch, AniWave, Gogoanime, Marin, torrents
 
 #### Quality Tier List
 


### PR DESCRIPTION
Added a new quality comparison using "[Masamune-kun no Revenge R](https://slow.pics/c/rj3QjRMA)," comparing a variety of sources including an encode, official, minis, and streaming sites.

Other minor changes include:
- Replacing "Web" to "WEB" for proper terminology
- Changing SubsPlease to be an "Official" source rather than an "Encode," which was previously incorrect