### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ thewiki is built using [Retype](https://retype.com). See how you can host a loca
    - The `retype start` command automatically prepares and loads the website into the browser:
 
      ```sh
-     retype start thewiki
+     retype start
      ```
 
    - Alternatively, you can use `retype build` to build it without running it:
 
      ```sh
-     retype build thewiki --output retype
+     retype build --output retype
      ```
 
 ## Contributing


### PR DESCRIPTION
```retype build thewiki``` and  ```retype build thewiki --output retype``` do not behave as expected. ```retype build thewiki``` initializes a default, new Retype project called thewiki; ```retype build thewiki --output retype``` return an error stating that the input directory "thewiki" does not exist. ```retype build``` and ```retype build --output retype``` are the functional equivalents to these two commands.