### PR TITLE
chore: design consistency and cleanup

### DIFF
--- a/docs/getting-started/anime.md
+++ b/docs/getting-started/anime.md
@@ -30,16 +30,17 @@ If you like convenience, streaming sites can be a perfectly fine option for your
 ||| Pros
 
 - No or minimal setup required
-- Easy to use and access from all your devices
+- Easy to use and can be accessed from all your devices
 - No VPN required; no copyright infringement notices from your ISP
 - Can be completely free
 
 ||| Cons
 
-- [Video and audio quality may be worse than other sources](/guides/quality/#quality-comparisons), such as Blu-rays
+- [Video and audio quality may be worse compared to other sources](/guides/quality/#quality-comparisons), such as official Blu-rays
+- May not use or be updated to use [Blu-rays](/guides/quality/#blu-ray-vs-web)
 - May not permit downloading/offline playback
 - Limited show availability; some shows may be unavailable in your region
-- May have ads or pop-ups
+- May contain ads or pop-ups
 |||
 
 *See the [streaming sites](/sourcing/streaming/) sourcing guide and [quality guide](/guides/quality) for more information.*
@@ -66,7 +67,7 @@ If you like to prioritize quality, torrenting can be an amazing option for your 
 
 - Requires some setup
 - May be hard to access or impossible on certain devices, such as TVs
-- May be illegal where you live; *a [VPN](/getting-started/torrenting/#vpn) may be necessary*
+- May be illegal where you live; a [VPN](/getting-started/torrenting/#vpn) may be necessary
 - May require some payment, such as a premium VPN subscription
 
 |||
@@ -83,12 +84,14 @@ Below is a brief list of recommended media player applications:
 
 +++ :desktop_computer: PC
 
-- [mpv](https://mpv.io/installation/) [!badge icon=":heart:" variant="primary" text="Recommended"]
-- [MPC-HC](https://github.com/clsid2/mpc-hc/releases)
-- [Potplayer](https://potplayer.daum.net)
+- [mpv](https://mpv.io/installation/) [!badge icon=":heart:" variant="primary" text="Recommended"] [!badge icon="sliders" variant="info" text="Setup Guide"](/tutorials/mpv)
 
 !!!warning
-VLC is not recommended as it introduces visual artifacts, displays wrong colors, and breaks intensive subtitles.
+The following players are **not recommended** and should be avoided:
+
+- [MPC-HC](https://github.com/clsid2/mpc-hc) - Outdated with lower-quality rendering, with or without madVR
+- [Potplayer](https://potplayer.daum.net/) - Has previously [shipped with adware](https://forum.videohelp.com/threads/393452-PotPlayer-now-Adware%21)
+- [VLC](https://www.videolan.org/vlc/) - Introduces visual artifacts, displays wrong colors, and breaks intensive subtitles. *See the comparisons with [Spice and Wolf](https://slow.pics/c/XhbmrYgU) and [One Piece](https://slow.pics/c/FW2nBwKP)*
 !!!
 
 +++ :robot_face: Android
@@ -106,7 +109,6 @@ VLC is not recommended as it introduces visual artifacts, displays wrong colors,
 
 - [Kodi](https://kodi.tv) [!badge icon=":heart:" variant="primary" text="Recommended"]
 - [Plex](https://www.plex.tv) [!badge icon=":heart:" variant="primary" text="Recommended"]
-- [Emby](https://emby.media)
 - [Jellyfin](https://jellyfin.org)
 
 +++

--- a/docs/guides/playback.md
+++ b/docs/guides/playback.md
@@ -14,12 +14,11 @@ image: /static/tohsaka.gif
 - [mpv](https://mpv.io/installation/) [!badge icon=":heart:" variant="primary" text="Recommended"] [!badge icon="sliders" variant="info" text="Setup Guide"](/tutorials/mpv)
 
 !!!warning
-Players that you should avoid:
-1. [VLC](https://www.videolan.org/vlc/) - Introduces visual artifacts, displays wrong colors, and breaks intensive subtitles. Examples: [Spice and Wolf](https://slow.pics/c/XhbmrYgU), [One Piece](https://slow.pics/c/FW2nBwKP)
+The following players are **not recommended** and should be avoided:
 
-2. [Potplayer](https://potplayer.daum.net/) - Has previously [shipped with adware](https://forum.videohelp.com/threads/393452-PotPlayer-now-Adware%21).
-
-3. [MPC-HC](https://github.com/clsid2/mpc-hc) - Outdated, with lower-quality rendering, with or without madVR.
+- [MPC-HC](https://github.com/clsid2/mpc-hc) - Outdated with lower-quality rendering, with or without madVR
+- [Potplayer](https://potplayer.daum.net/) - Has previously [shipped with adware](https://forum.videohelp.com/threads/393452-PotPlayer-now-Adware%21)
+- [VLC](https://www.videolan.org/vlc/) - Introduces visual artifacts, displays wrong colors, and breaks intensive subtitles. *See the comparisons with [Spice and Wolf](https://slow.pics/c/XhbmrYgU) and [One Piece](https://slow.pics/c/FW2nBwKP)*
 !!!
 
 +++ :robot_face: Android

--- a/docs/guides/playback.md
+++ b/docs/guides/playback.md
@@ -49,13 +49,12 @@ The setup consists of two parts: the **server** and the **client**. *Both may be
 
 In a typical setup, the server is installed on a computer hosted on your home network, with the client being installed on all your devices. Most media players will also come with their own client, as well as including support for using [Kodi](https://kodi.tv) as a client (recommended for anime).
 
-[!button variant="secondary" text="Emby" margin="0 8 0 0"](https://emby.media)
-[!button variant="secondary" text="Plex" margin="0 8 0 0"](https://www.plex.tv)
-[!button variant="secondary" text="Jellyfin"](https://jellyfin.org)
+[!button variant="secondary" text="Jellyfin" margin="0 8 0 0"](https://jellyfin.org)
+[!button variant="secondary" text="Plex"](https://www.plex.tv)
 
 !!!
 Running a media server requires a rigid folder structure and a specific file naming scheme.
-*See the guides for your server: [Plex](https://support.plex.tv/articles/naming-and-organizing-your-movie-media-files/), [Jellyfin](https://jellyfin.org/docs/general/server/media/shows)*
+*See the guides for your server: [Jellyfin](https://jellyfin.org/docs/general/server/media/shows), [Plex](https://support.plex.tv/articles/naming-and-organizing-your-movie-media-files/)*
 !!!
 
 ### Kodi

--- a/docs/guides/quality.md
+++ b/docs/guides/quality.md
@@ -188,13 +188,17 @@ Alternatively, you can use the [ABX Comparator plugin for foobar2000](https://ww
 *If you manage to complete it with a decent probability, feel free to join our [Discord](https://discord.gg/snackbox) to talk about it!*
 !!!
 
-A good benchmark for lossy audio bitrates (Stereo/2.0) is:
+A good baseline for lossy audio bitrates is:
 
-- 128Kbps for Opus
-- 160Kbps for AAC
-- 192Kbps for MP3
+Format | Stereo (2.0, 2 channels) | Surround (5.1, 6 channels)
+-------|--------------------------|-----------------------------
+AAC    | 160 kb/s                 | 480 kb/s
+MP3    | 192 kb/s                 | 576 kb/s
+Opus   | 128 kb/s                 | 384 kb/s
 
-For surround audio, multiply them by the number of stereo pairs.
+!!!info
+For surround audio, multiply them by the number of stereo pairs (2 channels).
+!!!
 
 ## Subtitles
 

--- a/docs/tutorials/comparison.md
+++ b/docs/tutorials/comparison.md
@@ -77,12 +77,13 @@ Download and install [`vs-jet`](https://github.com/Jaded-Encoding-Thaumaturgy/vs
 ```powershell
 python -m pip install vsjet
 ```
+
 ```powershell
 python -m vsjet latest
 ```
 
-!!!
-As of writing this, installing [`vs-preview`](https://github.com/Jaded-Encoding-Thaumaturgy/vs-preview) directly from PyPI or git is broken. You have to install it using [`vs-jet`](https://github.com/Jaded-Encoding-Thaumaturgy/vs-jet) which will install all JET packages.
+!!!warning
+Currently, installing [`vs-preview`](https://github.com/Jaded-Encoding-Thaumaturgy/vs-preview) directly from PyPI or git is broken. Instead, you have to install it using [`vs-jet`](https://github.com/Jaded-Encoding-Thaumaturgy/vs-jet), which will install all necessary JET packages.
 !!!
 
 ## Usage
@@ -191,15 +192,15 @@ clip3 = core.std.SetFieldBased(clip3, 0)
 
 Quick inverse telecine filter for converting telecined clips (usually 30 fps interlaced video) back to the original framerate (24 fps progressive).
 
+!!!warning
+[`vivtc`](https://github.com/vapoursynth/vivtc) needs to be installed in order for the following snippet to work. You can install it with `vsrepo.py install vivtc`.
+!!!
+
 ```py
 ## Inverse telecine: Fixes telecined video
 clip1 = core.vivtc.VFM(clip1, 1)
 clip1 = core.vivtc.VDecimate(clip1)
 ```
-
-!!!
-You need [`vivtc`](https://github.com/vapoursynth/vivtc) installed for the above snippet to work. You can install it with `vsrepo.py install vivtc`.
-!!!
 
 ==- :icon-file-media: Framing (cropping, scaling, trimming)
 
@@ -900,7 +901,7 @@ If you plan on uploading to [Slowpoke Pics](https://slow.pics) (slow.pics) under
 - Visit [Slowpoke Pics](https://slow.pics) in your browser and log into your account
 - Open your browser's **Developer Tools**. You will need to get two values:
   - To get your `browserId`, go to **Application** -> **Storage** -> **Local Storage** -> `https://slow.pics`. Copy the key listed there
-  - To get your `sessionId`, go to **Network**. Refresh the page, then find `slow.pics`. On the right section open cookies and copy the `SLP-SESSION` value
+  - To get your `sessionId`, go to **Network**. Refresh the page, then find `slow.pics`. In the right-hand section, go to **Cookies** and copy the **Value** listed under `SLP-SESSION`
 - In VSPreview, go to **Settings** -> **Comp**
 - Paste the two values in the boxes provided
 

--- a/docs/tutorials/comparison.md
+++ b/docs/tutorials/comparison.md
@@ -83,7 +83,7 @@ python -m vsjet latest
 ```
 
 !!!warning
-Currently, installing [`vs-preview`](https://github.com/Jaded-Encoding-Thaumaturgy/vs-preview) directly from PyPI or git is broken. Instead, you have to install it using [`vs-jet`](https://github.com/Jaded-Encoding-Thaumaturgy/vs-jet), which will install all necessary JET packages.
+Currently, installing [`vs-preview`](https://github.com/Jaded-Encoding-Thaumaturgy/vs-preview) directly from PyPI or git is broken. Instead, you have to install it using [`vs-jet`](https://github.com/Jaded-Encoding-Thaumaturgy/vs-jet), which will install all JET packages.
 !!!
 
 ## Usage

--- a/docs/tutorials/mpv.md
+++ b/docs/tutorials/mpv.md
@@ -57,14 +57,14 @@ scoop uninstall mpv-git
 
 ==- 🍴 Installing a fork
 
+!!!info
+We suggest sticking with the official mpv player as forks tend to lag behind in updates.
+!!!
+
 [mpv](https://mpv.io) can also be found in the various forks below:
 
-- [mpv.net](https://github.com/mpvnet-player/mpv.net) [!badge icon="apps" variant="info" text="Microsoft Store"](https://apps.microsoft.com/store/detail/9N64SQZTB3LM)
 - [mpc-qt](https://github.com/mpc-qt/mpc-qt)
-
-!!!
-Consider using the official mpv as forks tend to lag behind in updates.
-!!!
+- [mpv.net](https://github.com/mpvnet-player/mpv.net) [!badge icon="apps" variant="info" text="Microsoft Store"](https://apps.microsoft.com/store/detail/9N64SQZTB3LM)
 
 ==- 📦 Installing a pre-configured build
 
@@ -240,7 +240,7 @@ Color banding is a visual artifact that is typically seen in gradients, where th
 <p align="center">Banding (left) vs. No banding (right)</p>
 </p>
 
-mpv ships with debanding capabilities so you don't have to do anything. Simply enable debanding during playback by pressing `b` (default keybind).
+Newer versions of mpv now ship with debanding capabilities, so no additional configuration is required. You can enable debanding anytime during playback by pressing `b` (default keybind).
 
 ### Scaling
 
@@ -251,10 +251,11 @@ Scaling is the process of taking content that does not match your screen resolut
 Scalers only work when the resolution of your video does not match your display. They do not activate if the content resolution already matches your display resolution.
 
 +++ High-End PCs
+
 If you use high-end hardware, we recommend using the following shaders:
 
-- [nnedi3-nns128-win8x4.hook](https://github.com/bjin/mpv-prescalers/blob/master/compute/nnedi3-nns128-win8x4.hook) for lower quality sources.
-- [ArtCNN_C4F32.glsl](https://github.com/Artoriuz/ArtCNN/blob/main/ArtCNN_C4F32.glsl) for higher quality sources.
+- [ArtCNN_C4F32.glsl](https://github.com/Artoriuz/ArtCNN/blob/main/ArtCNN_C4F32.glsl) for higher quality sources
+- [nnedi3-nns128-win8x4.hook](https://github.com/bjin/mpv-prescalers/blob/master/compute/nnedi3-nns128-win8x4.hook) for lower quality sources
 
 Download both the shader files and place them in your `shaders` folder.
 
@@ -262,9 +263,10 @@ Next, add the following to your `input.conf`, replacing `g` with the bind of you
 
 :::code source="/static/tutorials/mpv/portable_config/input.conf" range="2" language="properties":::
 
-Now you can simply press `g` during playback to select the suitable shader.
+To toggle the shader, press `g` during playback to select the suitable shader.
 
 +++ Mid-Range PCs
+
 If you use mid-range hardware, we recommend sticking to mpv's built-in `high-quality` profile.
 
 To use the profile, add the following to the top of your `mpv.conf`:
@@ -275,10 +277,11 @@ This is included in the [Basic Config](#basic-config).
 
 +++ Low-End PCs
 
-If you use low-end hardware, we recommend sticking to mpv's default profile, which aims for a balance between quality and performance. You don't need to make any changes to achieve this, as it's the default preset.
+If you use low-end hardware, we recommend sticking to mpv's default profile, which aims for a balance between quality and performance. No other changes need to be made as it is used by default.
 
 +++ Potato PCs
-If you use ultra low-end hardware, we recommend sticking to mpv's built-in `fast` profile, which prioritizes performance over quality.
+
+If you use very low-end hardware, we recommend sticking to mpv's `fast` profile, which prioritizes performance over quality.
 
 To use the profile, add the following to the top of your `mpv.conf`:
 
@@ -290,12 +293,17 @@ profile=fast
 
 ### Dither
 
-Dither is an intentionally applied form of noise used to randomize quantization error, preventing large-scale patterns such as color banding in images. mpv applies dither to match the content bit-depth to your monitor's bit-depth but it may fail to detect the correct bit-depth of your monitor automatically in which case the wrong bit-depth will end up **adding** banding during playback.
+Dither is an intentionally applied noise filter that aims to help eliminate various visual artifacts, such as color banding during playback.
 
-To avoid introducing banding during playback, explicitly set your monitor's bit-depth in `mpv.conf`:
+By default, mpv uses dithering to match the content bit depth to your display's bit depth. *However, in some instances, it may fail to detect the correct bit depth of your display automatically, causing the wrong bit depth to be used and adding banding during playback.*
+
+To avoid introducing banding during playback, we recommend explicitly defining your display's bit depth. Most modern displays use the 8-bit color depth, however you can manually check this:
+
+- For Windows, this can be found in **Settings** -> **Display** -> **Advanced display settings** -> **Display information** -> **Bit depth**
+
+Then, set your display's bit depth in your `mpv.conf`:
 
 :::code source="/static/tutorials/mpv/portable_config/mpv.conf" range="8" language="properties":::
-
 
 ### Subtitle Restyling
 


### PR DESCRIPTION
This commit includes various cleanup fixes and consistency changes, some which rectify issues from previous commits.

Some changes include:
- `getting-started/anime`: Slightly changed terminology and updated playback table to reflect `guides/playback`
- `guides/quality`: Used table for lossy audio bitrate baselines and added surround conversions
- `tutorials/mpv`: Simplified dithering intro