### PR TITLE
dvdremux.md: set exact aspect ratio

### DIFF
--- a/docs/tutorials/dvdremux.md
+++ b/docs/tutorials/dvdremux.md
@@ -365,7 +365,7 @@ we can print out the new display dimensions
 to use with mkvpropedit like so:
 
 ```py
-print([round(width), round(height)])
+print(new_sar * clip.width / clip.height)
 ```
 
 ### Applying the corrected SAR/PAR
@@ -374,7 +374,7 @@ Once we've obtained these new display dimensions,
 we can edit the mkv with the following terminal command:
 
 ```shell
-mkvpropedit <filename>.mkv --edit track:v1 --set display-width=<display_width> --set display-height=<display_height>
+mkvpropedit <filename>.mkv --edit track:v1 --set display-unit=3 --set display-width=<display_width> --set display-height=<display_height>
 ```
 
 Replace:
@@ -386,7 +386,7 @@ Replace:
 This command is incomplete, however.
 In order for fully correct playback
 we need to set additional cropping flags
-so the video is cropped to it's respective active area.
+so the video is cropped to its respective active area.
 This can be done by adding the following to the above command:
 
 ```shell
@@ -406,10 +406,10 @@ more black/faded columns.
 If your disc has black borders on the top or bottom,
 you should additionally set the top/bottom pixel crop flags.
 
-Below is an example of a complete command:
+Below is an example of a complete command (for a 16:9 video with active area 711x480 and a top black bar):
 
 ```shell
-mkvpropedit test.mkv --edit track:v1 --set display-width=864 --set display-height=480 --set pixel-crop-left=5 --set pixel-crop-right=4 --set pixel-crop-top=4
+mkvpropedit test.mkv --edit track:v1 --set display-unit=3 --set display-width=1280 --set display-height=711 --set pixel-crop-left=5 --set pixel-crop-right=4 --set pixel-crop-top=4
 ```
 
 After this your SAR/PAR correction is done and the DVD remux is complete.


### PR DESCRIPTION
Matroska’s display dimensions don’t have to be given in absolute pixels. They can be an exact fraction, which allows the file to be displayed more accurately when combined with upscaling and/or cropping. For maximum compliance with the Matroska spec, set `display-unit` to 3, which means “display aspect ratio”; the default is 0, meaning “pixels”.

cc @wiwaz

Extra notes:

* In some situations, rounding might be more convenient (e. g. if the remux is gonna be subtitled in ASS with pixel-perfect typesetting; although that will break in the presence of container crop regardless of the aspect ratio).

* When `width` and `height` are both exact integers, the display dimensions could be set in pixels and be exact, too. I would do this, personally (out of an overabundance of caution regarding media player/toolchain compatibility), but I haven’t included this in order to keep the guide simple.

* I don’t remember ever encountering a software that cared about `display-unit`, and I’ve just double-checked mpv, VLC, MPC-HC, MediaInfo, FFprobe. Everything always treats it as a relative ratio and never as absolute pixels. But FWIW MKVToolNix has a [13-year-old commit](https://gitlab.com/mbunkus/mkvtoolnix/-/commit/35b1bb1771) that suggests some software _might_ have interpreted display dimensions as absolute pixels, although it doesn’t give any names or make it clear whether setting `display-unit` even helped. My main worry would normally be TVs/media servers/etc., but they typically scale the output to a full screen, making this irrelevant.

* The table entries for 711x480 are guesstimates and produce aspect ratios with awfully many significant digits, which may raise some questions. (With rounded dimensions, this didn’t matter, but with exact fractions, this is fully preserved in the file.) They could be simplified to sample ARs of 9:10 (for 4:3) and 6:5 (for 16:9), causing only a subpixel difference (or in practice, due to rounding in media players, no difference at all) even after upscaling to modern screen resolutions. These ARs correspond to active areas of 720×486 (exactly) or 711.111…×480.

  Similarly, one could instead assume an active area of 710.85×480 and produce some other horrible aspect ratio without a noticeable difference; but especially for downscaled HD content, 720×486 seems more enticing. FWIW I have an SD analogue-production 4:3 DVD from 1999 (Digimon Adventure) that seems to use this AR, and its horizontal area is in fact filled with darkened garbage outside of roughly 711 pixels, but in some scenes it does seem cropped out of a larger picture (I’d say ~718×486), so maybe multiple conversions were involved.

  On the other hand, this guide also recommends setting container crop, and container crop is always a whole number of storage pixels, so it is convenient if the supposed active area ends up having a whole number of display pixels after this cropping takes place and the cropped image is rescaled for display. 711×480 happens to achieve this for 4:3: the display area will be exactly 640x480.