### PR TITLE
fix(hentai) update Anchira's link and onion link

### DIFF
--- a/docs/getting-started/hentai.md
+++ b/docs/getting-started/hentai.md
@@ -46,8 +46,8 @@ author:
 - Requires an E-Hentai account to be logged in to access. If the site remains blank after this, clear your browser's cookies or open a private tab and log in through there. 
 - Wider collection of content than E-Hentai.
 
-[Anchira](https://koharu.to/)
-- Backup onionsite archive [here](fakkunet27t5i5laxfyrrxqqndpd53do73vi4bbj6jcf7wfdszjukmid.onion)
+[Anchira](https://schale.network/)
+- Backup onionsite archive [here](http://fakkunet27t5i5laxfyrrxqqndpd53do73vi4bbj6jcf7wfdszjukmid.onion)
 - If neither E-Hentai nor Ex-Hentai have what you're looking for, there's a fair chance it may be on here. This site boasts an ever-growing collection of English-published doujinshi that oftentimes is from a blacklisted publisher on the aforementioned sites.
 
 [Nhentai](https://nhentai.net/) - Scrapes and packages E-Hentai's content into a simple, cleaner design. Preferred by many for its minimalistic feel and easy navigation.


### PR DESCRIPTION
Fixed Anchira's links:
- Changed Anchira's link from koharu.to (which is now dead) to an "observer" schale.network, which always redirects to one of Anchira's domains with the highest availability.
- Added `http://` to the onion link to Anchira, since it didn't work properly, treating it as an internal link on The Wiki.