### PR TITLE
fix: prefer vstools.set_output

### DIFF
--- a/docs/tutorials/comparison.md
+++ b/docs/tutorials/comparison.md
@@ -82,9 +82,8 @@ Make sure to comment (add `##` to the beginning of the line) and uncomment lines
 ```py
 ## Dependencies: Allows vspreview to run [required; do not remove]
 import vstools
-from vstools import vs, core
+from vstools import vs, core, set_output
 from vskernels import Hermite, EwaLanczos
-from vspreview import set_output
 
 ## <Additional dependencies>
 ## Place any additional dependencies you want to use in your comp here


### PR DESCRIPTION
`vspreview.set_output()` is currently a no-op outside of vspreview. While this isn't an issue in the context of the Comparison tutorial, I've seen at least a couple of users run into issues where they take snippets from the tutorial and try to use them in a quick encode (e.g. the quick inverse telecine snippet). The issue is because their `vspreview.set_output()` usage isn't outputting anything when used via vspipe.

While this shouldn't be the Comparison tutorial's concern, I think it'd be better to settle on recommending the higher-level `vstools.set_output()` API instead. It also means one less import line.