### PR TITLE
Fix syntax, reword scaling instructions

### DIFF
--- a/docs/tutorials/comparison.md
+++ b/docs/tutorials/comparison.md
@@ -186,7 +186,7 @@ Scaling should be used for all sources that have *differing resolutions* so they
 
 
 For example, if you have a 720p and 1080p source, you can either:
- - Upscale the 720p source to 1080p using `EwaLanczos`
+ - Upscale the 720p source to 1080p using `EwaLanczos`.
 
   ```py
   ## Scaling: Modify the output resolution of specified clips, use EwaLanczos for upscaling OR Hermite for downscaling (both are equivalent scaling to mpv's high-quality profile)
@@ -195,8 +195,8 @@ For example, if you have a 720p and 1080p source, you can either:
 
 **Or**
 
- - Downscale the 1080p source to 720p using `Hermite`
-   - **Warning: Downscaling produces worse results and is not recommended for comparisons**
+ - Downscale the 1080p source to 720p using `Hermite`.
+   - **Warning: Downscaling produces worse results and is not recommended for comparisons.**
 
   ```py
   ## Scaling: Modify the output resolution of specified clips, use EwaLanczos for upscaling OR Hermite for downscaling (both are equivalent scaling to mpv's high-quality profile)
@@ -204,7 +204,7 @@ For example, if you have a 720p and 1080p source, you can either:
   ```
 
 !!!warning
-If the colors of your sources do not match after upscaling, see the Color Spaces section below
+If the colors of your sources do not match after upscaling, see the Color Spaces section below.
 !!!
 
 #### Trimming


### PR DESCRIPTION
I found the current comment in the example for scaling rather confusing, it led me to believe the command needed the resolution for all clips set and then it would upscale them all to the one with the highest resolution.

Of course that doesn't make much sense, and I thought it was weird while I was reading it too.

Also, syntax fix for the scaling command so people don't get this error with new versions:
```
_SyntaxMethod: The `scale` method must be called on an instance, not the class. For example, use: Bicubic().scale(...) instead of Bicubic.scale(...)
```